### PR TITLE
Cairo runner tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 /target
 
 llvm/
+
+# Added so we can have our own specific development scripts
+scripts/

--- a/examples/print_test.ll
+++ b/examples/print_test.ll
@@ -7,7 +7,21 @@ declare void @free(ptr)
 
 declare i32 @printf(ptr, ...)
 
-define internal void @print_felt(i256 %0) {
+define internal i256 @"store_temp<felt252>"(i256 %0) {
+  ret i256 %0
+}
+
+define i256 @print_test_print_test_main() {
+  %1 = call i256 @"store_temp<felt252>"(i256 24)
+  ret i256 %1
+}
+
+define i256 @_mlir_ciface_print_test_print_test_main() {
+  %1 = call i256 @print_test_print_test_main()
+  ret i256 %1
+}
+
+define internal void @print_felt252(i256 %0) {
   %2 = ashr i256 %0, 224
   %3 = trunc i256 %2 to i32
   %4 = alloca i8, i64 5, align 1
@@ -53,19 +67,15 @@ define internal void @print_felt(i256 %0) {
   ret void
 }
 
-define internal i256 @"store_temp<felt252>"(i256 %0) {
-  ret i256 %0
+define void @main() {
+  %1 = call i256 @print_test_print_test_main()
+  call void @print_felt252(i256 %1)
+  ret void
 }
 
-define i256 @main() {
-  %1 = call i256 @"store_temp<felt252>"(i256 24)
-  call void @print_felt(i256 %1)
-  ret i256 %1
-}
-
-define i256 @_mlir_ciface_main() {
-  %1 = call i256 @main()
-  ret i256 %1
+define void @_mlir_ciface_main() {
+  call void @main()
+  ret void
 }
 
 !llvm.module.flags = !{!0}

--- a/examples/print_test.mlir
+++ b/examples/print_test.mlir
@@ -1,6 +1,18 @@
 module attributes {llvm.data_layout = ""} {
   llvm.func @printf(!llvm.ptr, ...) -> i32
-  llvm.func internal @print_felt(%arg0: i256) {
+  llvm.func internal @"store_temp<felt252>"(%arg0: i256) -> i256 {
+    llvm.return %arg0 : i256
+  }
+  llvm.func @print_test_print_test_main() -> i256 attributes {llvm.emit_c_interface} {
+    %0 = llvm.mlir.constant(24 : i256) : i256
+    %1 = llvm.call @"store_temp<felt252>"(%0) : (i256) -> i256
+    llvm.return %1 : i256
+  }
+  llvm.func @_mlir_ciface_print_test_print_test_main() -> i256 attributes {llvm.emit_c_interface} {
+    %0 = llvm.call @print_test_print_test_main() : () -> i256
+    llvm.return %0 : i256
+  }
+  llvm.func internal @print_felt252(%arg0: i256) {
     %0 = llvm.mlir.constant(224 : i256) : i256
     %1 = llvm.ashr %arg0, %0  : i256
     %2 = llvm.trunc %1 : i256 to i32
@@ -71,17 +83,13 @@ module attributes {llvm.data_layout = ""} {
     %58 = llvm.call @printf(%56) : (!llvm.ptr) -> i32
     llvm.return
   }
-  llvm.func internal @"store_temp<felt252>"(%arg0: i256) -> i256 {
-    llvm.return %arg0 : i256
+  llvm.func @main() attributes {llvm.emit_c_interface} {
+    %0 = llvm.call @print_test_print_test_main() : () -> i256
+    llvm.call @print_felt252(%0) : (i256) -> ()
+    llvm.return
   }
-  llvm.func @main() -> i256 attributes {llvm.emit_c_interface} {
-    %0 = llvm.mlir.constant(24 : i256) : i256
-    %1 = llvm.call @"store_temp<felt252>"(%0) : (i256) -> i256
-    llvm.call @print_felt(%1) : (i256) -> ()
-    llvm.return %1 : i256
-  }
-  llvm.func @_mlir_ciface_main() -> i256 attributes {llvm.emit_c_interface} {
-    %0 = llvm.call @main() : () -> i256
-    llvm.return %0 : i256
+  llvm.func @_mlir_ciface_main() attributes {llvm.emit_c_interface} {
+    llvm.call @main() : () -> ()
+    llvm.return
   }
 }

--- a/sierra2mlir/Cargo.toml
+++ b/sierra2mlir/Cargo.toml
@@ -21,4 +21,10 @@ itertools = "0.10.5"
 regex = "1.7.1"
 
 [dev-dependencies]
+anyhow = "1.0.70"
+cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
 criterion = "0.4.0"
+num-bigint = "0.4.3"
+num-traits = "0.2.15"
+tempdir = "0.3.7"
+test-case = "3.0.0"

--- a/sierra2mlir/Cargo.toml
+++ b/sierra2mlir/Cargo.toml
@@ -21,7 +21,6 @@ itertools = "0.10.5"
 regex = "1.7.1"
 
 [dev-dependencies]
-anyhow = "1.0.70"
 cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
 criterion = "0.4.0"
 num-bigint = "0.4.3"

--- a/sierra2mlir/src/compiler.rs
+++ b/sierra2mlir/src/compiler.rs
@@ -14,6 +14,8 @@ use melior_next::{
 use regex::Regex;
 use std::{borrow::Cow, cell::RefCell, collections::HashMap, rc::Rc};
 
+use crate::types::DEFAULT_PRIME;
+
 pub struct Compiler<'ctx> {
     pub code: String,
     pub program: Program,
@@ -144,7 +146,7 @@ impl<'ctx> Compiler<'ctx> {
         // The prime number is a double felt as it's always used for modulo.
         self.op_const(
             block,
-            "3618502788666131213697322783095070105623107215331596699973092056135872020481",
+            DEFAULT_PRIME,
             self.double_felt_type(),
         )
     }
@@ -582,7 +584,7 @@ impl<'ctx> Compiler<'ctx> {
 
         let felt_type = self.felt_type();
         let location = Location::unknown(&self.context);
-        let prime = "3618502788666131213697322783095070105623107215331596699973092056135872020481";
+        let prime = DEFAULT_PRIME;
 
         let fib_function = {
             let fib_region = Region::new();

--- a/sierra2mlir/src/compiler.rs
+++ b/sierra2mlir/src/compiler.rs
@@ -34,6 +34,15 @@ pub enum SierraType<'ctx> {
     },
 }
 
+impl<'ctx> SierraType<'ctx> {
+    pub fn get_type(&self) -> &Type<'ctx> {
+        match self {
+            SierraType::Simple(ty) => ty,
+            SierraType::Struct { ty, field_types: _ } => ty,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FunctionDef<'ctx> {
     #[allow(unused)]

--- a/sierra2mlir/src/compiler.rs
+++ b/sierra2mlir/src/compiler.rs
@@ -144,11 +144,7 @@ impl<'ctx> Compiler<'ctx> {
 
     pub fn prime_constant<'a>(&self, block: &'a Block) -> OperationRef<'a> {
         // The prime number is a double felt as it's always used for modulo.
-        self.op_const(
-            block,
-            DEFAULT_PRIME,
-            self.double_felt_type(),
-        )
+        self.op_const(block, DEFAULT_PRIME, self.double_felt_type())
     }
 
     /// Only the MLIR op, doesn't do modulo.

--- a/sierra2mlir/src/compiler.rs
+++ b/sierra2mlir/src/compiler.rs
@@ -35,7 +35,7 @@ pub enum SierraType<'ctx> {
 }
 
 impl<'ctx> SierraType<'ctx> {
-    pub fn get_type(&self) -> &Type<'ctx> {
+    pub const fn get_type(&self) -> &Type<'ctx> {
         match self {
             SierraType::Simple(ty) => ty,
             SierraType::Struct { ty, field_types: _ } => ty,

--- a/sierra2mlir/src/lib.rs
+++ b/sierra2mlir/src/lib.rs
@@ -13,7 +13,7 @@ use crate::compiler::Compiler;
 pub mod compiler;
 mod libfuncs;
 mod statements;
-mod types;
+pub mod types;
 mod utility;
 
 pub fn compile(

--- a/sierra2mlir/src/lib.rs
+++ b/sierra2mlir/src/lib.rs
@@ -26,12 +26,9 @@ pub fn compile(
 
     if main_print {
         compiler.create_printf()?;
-        compiler.create_print_felt()?;
     }
 
     compiler.compile()?;
-
-    if main_print {}
 
     println!("{}", compiler.module.as_operation());
     let pass_manager = pass::Manager::new(&compiler.context);

--- a/sierra2mlir/src/libfuncs/mod.rs
+++ b/sierra2mlir/src/libfuncs/mod.rs
@@ -6,7 +6,10 @@ use itertools::Itertools;
 use melior_next::ir::{Block, BlockRef, Location, Region, Type, Value};
 use tracing::debug;
 
-use crate::compiler::{Compiler, FunctionDef, SierraType, Storage};
+use crate::{
+    compiler::{Compiler, FunctionDef, SierraType, Storage},
+    statements::create_fn_signature,
+};
 
 impl<'ctx> Compiler<'ctx> {
     pub fn process_libfuncs(&'ctx self, storage: Rc<RefCell<Storage<'ctx>>>) -> Result<()> {
@@ -91,7 +94,7 @@ impl<'ctx> Compiler<'ctx> {
     ) -> Result<()> {
         let id = Self::normalize_func_name(func_decl.id.debug_name.as_ref().unwrap().as_str())
             .to_string();
-        let mut args = vec![];
+        let mut arg_types_with_locations = vec![];
 
         for arg in &func_decl.long_id.generic_args {
             let storage = RefCell::borrow(&*storage);
@@ -111,7 +114,7 @@ impl<'ctx> Compiler<'ctx> {
                     };
 
                     for ty in field_types {
-                        args.push((*ty, Location::unknown(&self.context)));
+                        arg_types_with_locations.push((*ty, Location::unknown(&self.context)));
                     }
                 }
                 GenericArg::Value(_) => todo!(),
@@ -122,11 +125,11 @@ impl<'ctx> Compiler<'ctx> {
 
         let region = Region::new();
 
-        let block = Block::new(&args);
+        let block = Block::new(&arg_types_with_locations);
 
-        let types = args.iter().map(|x| x.0).collect_vec();
-        let struct_llvm_type = self.struct_type_string(&types);
-        let mut struct_type_op = self.op_llvm_struct(&block, &types);
+        let arg_types = arg_types_with_locations.iter().map(|x| x.0).collect_vec();
+        let struct_llvm_type = self.struct_type_string(&arg_types);
+        let mut struct_type_op = self.op_llvm_struct(&block, &arg_types);
         //let mut struct_value: Value = struct_type_op.result(0)?.into();
 
         for i in 0..block.argument_count() {
@@ -140,8 +143,7 @@ impl<'ctx> Compiler<'ctx> {
         self.op_return(&block, &[struct_value]);
 
         let return_type = Type::parse(&self.context, &struct_llvm_type).unwrap();
-        let function_type =
-            self.create_fn_signature(&args, &[(return_type, Location::unknown(&self.context))]);
+        let function_type = create_fn_signature(&arg_types, &[return_type]);
 
         region.append_block(block);
 
@@ -152,7 +154,7 @@ impl<'ctx> Compiler<'ctx> {
             storage.functions.insert(
                 id,
                 FunctionDef {
-                    args: args.iter().map(|x| x.0).collect_vec(),
+                    args: arg_types,
                     return_types: vec![return_type],
                 },
             );
@@ -173,7 +175,7 @@ impl<'ctx> Compiler<'ctx> {
     ) -> Result<()> {
         let id = Self::normalize_func_name(func_decl.id.debug_name.as_ref().unwrap().as_str())
             .to_string();
-        let mut args = vec![];
+        let mut arg_types_with_locations = vec![];
 
         for arg in &func_decl.long_id.generic_args {
             let storage = RefCell::borrow(&*storage);
@@ -185,12 +187,8 @@ impl<'ctx> Compiler<'ctx> {
                         .get(&type_id.id.to_string())
                         .expect("type to exist");
 
-                    let ty = match ty {
-                        SierraType::Simple(ty) => ty,
-                        SierraType::Struct { ty, field_types: _ } => ty,
-                    };
-
-                    args.push((*ty, Location::unknown(&self.context)));
+                    arg_types_with_locations
+                        .push((*ty.get_type(), Location::unknown(&self.context)));
                 }
                 GenericArg::Value(_) => todo!(),
                 GenericArg::UserFunc(_) => todo!(),
@@ -200,7 +198,7 @@ impl<'ctx> Compiler<'ctx> {
 
         let region = Region::new();
 
-        let block = Block::new(&args);
+        let block = Block::new(&arg_types_with_locations);
 
         let mut results: Vec<Value> = vec![];
 
@@ -213,7 +211,12 @@ impl<'ctx> Compiler<'ctx> {
 
         region.append_block(block);
 
-        let function_type = self.create_fn_signature(&args, &args);
+        let arg_types = arg_types_with_locations
+            .iter()
+            .map(|(t, _)| *t)
+            .collect_vec();
+
+        let function_type = create_fn_signature(&arg_types, &arg_types);
 
         let func = self.op_func(&id, &function_type, vec![region], false, false)?;
 
@@ -222,8 +225,8 @@ impl<'ctx> Compiler<'ctx> {
             storage.functions.insert(
                 id,
                 FunctionDef {
-                    args: args.iter().map(|x| x.0).collect_vec(),
-                    return_types: args.iter().map(|x| x.0).collect(),
+                    args: arg_types.clone(),
+                    return_types: arg_types,
                 },
             );
         }
@@ -241,7 +244,7 @@ impl<'ctx> Compiler<'ctx> {
     ) -> Result<()> {
         let id = Self::normalize_func_name(func_decl.id.debug_name.as_ref().unwrap().as_str())
             .to_string();
-        let mut args = vec![];
+        let mut arg_types_with_locations = vec![];
 
         for arg in &func_decl.long_id.generic_args {
             let storage = RefCell::borrow(&*storage);
@@ -253,12 +256,8 @@ impl<'ctx> Compiler<'ctx> {
                         .get(&type_id.id.to_string())
                         .expect("type to exist");
 
-                    let ty = match ty {
-                        SierraType::Simple(ty) => ty,
-                        SierraType::Struct { ty, field_types: _ } => ty,
-                    };
-
-                    args.push((*ty, Location::unknown(&self.context)));
+                    arg_types_with_locations
+                        .push((*ty.get_type(), Location::unknown(&self.context)));
                 }
                 GenericArg::Value(_) => todo!(),
                 GenericArg::UserFunc(_) => todo!(),
@@ -268,7 +267,7 @@ impl<'ctx> Compiler<'ctx> {
 
         let region = Region::new();
 
-        let block = Block::new(&args);
+        let block = Block::new(&arg_types_with_locations);
 
         // Return the results, 2 times.
         let mut results: Vec<Value> = vec![];
@@ -288,11 +287,16 @@ impl<'ctx> Compiler<'ctx> {
 
         region.append_block(block);
 
-        let mut return_types = Vec::with_capacity(args.len() * 2);
-        return_types.extend_from_slice(&args);
-        return_types.extend_from_slice(&args);
+        let arg_types = arg_types_with_locations
+            .iter()
+            .map(|(t, _)| *t)
+            .collect::<Vec<_>>();
 
-        let function_type = self.create_fn_signature(&args, &return_types);
+        let mut return_types = Vec::with_capacity(arg_types.len() * 2);
+        return_types.extend_from_slice(&arg_types);
+        return_types.extend_from_slice(&arg_types);
+
+        let function_type = create_fn_signature(&arg_types, &return_types);
 
         let func = self.op_func(&id, &function_type, vec![region], false, false)?;
 
@@ -301,8 +305,8 @@ impl<'ctx> Compiler<'ctx> {
             storage.functions.insert(
                 id,
                 FunctionDef {
-                    args: args.iter().map(|x| x.0).collect_vec(),
-                    return_types: return_types.iter().map(|x| x.0).collect(),
+                    args: arg_types,
+                    return_types,
                 },
             );
         }

--- a/sierra2mlir/src/statements/mod.rs
+++ b/sierra2mlir/src/statements/mod.rs
@@ -70,7 +70,7 @@ impl<'ctx> Compiler<'ctx> {
 
             let raw_func_name = func.id.debug_name.as_ref().unwrap().as_str();
 
-            let should_create_wrapper = should_create_wrapper(raw_func_name);
+            let should_create_wrapper = self.main_print && should_create_wrapper(raw_func_name);
             let name = Self::normalize_func_name(raw_func_name).to_string();
 
             let entry = func.entry_point.0;

--- a/sierra2mlir/src/statements/mod.rs
+++ b/sierra2mlir/src/statements/mod.rs
@@ -286,7 +286,9 @@ impl<'ctx> Compiler<'ctx> {
 
                                             had_jump = true;
                                         }
-                                        _ => todo!("Branching function {} not implemented yet", name),
+                                        _ => {
+                                            todo!("Branching function {} not implemented yet", name)
+                                        }
                                     };
                                 }
                                 name => {

--- a/sierra2mlir/src/statements/mod.rs
+++ b/sierra2mlir/src/statements/mod.rs
@@ -532,7 +532,7 @@ fn get_all_types_to_print(
                         }
                     }
                 }
-                if !types_to_print.contains(&type_decl) {
+                if !types_to_print.contains(type_decl) {
                     types_to_print.push(type_decl.clone());
                 }
             }

--- a/sierra2mlir/src/statements/mod.rs
+++ b/sierra2mlir/src/statements/mod.rs
@@ -245,7 +245,7 @@ impl<'ctx> Compiler<'ctx> {
                                 }
                                 name if inv.branches.len() > 1 => {
                                     match name {
-                                        "felt_is_zero" => {
+                                        "felt252_is_zero" => {
                                             let felt_op_zero =
                                                 self.op_felt_const(current_block, "0");
                                             let zero = felt_op_zero.result(0)?.into();
@@ -286,7 +286,7 @@ impl<'ctx> Compiler<'ctx> {
 
                                             had_jump = true;
                                         }
-                                        _ => todo!(),
+                                        _ => todo!("Branching function {} not implemented yet", name),
                                     };
                                 }
                                 name => {

--- a/sierra2mlir/src/statements/mod.rs
+++ b/sierra2mlir/src/statements/mod.rs
@@ -64,7 +64,7 @@ impl<'c> Variable<'c> {
 
 impl<'ctx> Compiler<'ctx> {
     #[allow(clippy::cognitive_complexity)]
-    pub fn process_functions(&'ctx self, storage: Rc<RefCell<Storage<'ctx>>>) -> Result<()> {
+    pub fn process_functions(&self, storage: Rc<RefCell<Storage<'ctx>>>) -> Result<()> {
         for func in &self.program.funcs {
             debug!(?func, "processing func");
 

--- a/sierra2mlir/src/types/mod.rs
+++ b/sierra2mlir/src/types/mod.rs
@@ -8,7 +8,8 @@ use tracing::debug;
 
 use crate::compiler::{Compiler, SierraType, Storage};
 
-pub const DEFAULT_PRIME: &str = "3618502788666131213697322783095070105623107215331596699973092056135872020481";
+pub const DEFAULT_PRIME: &str =
+    "3618502788666131213697322783095070105623107215331596699973092056135872020481";
 
 impl<'ctx> Compiler<'ctx> {
     pub fn process_types(&'ctx self, storage: Rc<RefCell<Storage<'ctx>>>) -> Result<()> {

--- a/sierra2mlir/src/types/mod.rs
+++ b/sierra2mlir/src/types/mod.rs
@@ -8,6 +8,8 @@ use tracing::debug;
 
 use crate::compiler::{Compiler, SierraType, Storage};
 
+pub const DEFAULT_PRIME: &str = "3618502788666131213697322783095070105623107215331596699973092056135872020481";
+
 impl<'ctx> Compiler<'ctx> {
     pub fn process_types(&'ctx self, storage: Rc<RefCell<Storage<'ctx>>>) -> Result<()> {
         for type_decl in &self.program.type_declarations {

--- a/sierra2mlir/tests/comparison.rs
+++ b/sierra2mlir/tests/comparison.rs
@@ -2,9 +2,10 @@ use std::fs;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use anyhow::Context;
 use cairo_lang_runner::{RunResult, SierraCasmRunner};
 use cairo_lang_sierra::ProgramParser;
+use color_eyre::Result;
+use color_eyre::eyre::WrapErr;
 use num_bigint::BigUint;
 use num_traits::Num;
 use sierra2mlir::compile;
@@ -68,7 +69,7 @@ fn comparison_test(test_name: &str) -> Result<(), String> {
 
 // Invokes starkware's runner that compiles sierra to casm and runs it
 // This provides us with the intended results to compare against
-fn run_sierra_via_casm(sierra_code: &str) -> Result<RunResult, anyhow::Error> {
+fn run_sierra_via_casm(sierra_code: &str) -> Result<RunResult> {
     let sierra_program = ProgramParser::new().parse(sierra_code).unwrap();
 
     let runner = SierraCasmRunner::new(sierra_program, false)

--- a/sierra2mlir/tests/comparison.rs
+++ b/sierra2mlir/tests/comparison.rs
@@ -1,0 +1,153 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::Context;
+use cairo_lang_runner::{RunResult, SierraCasmRunner};
+use cairo_lang_sierra::ProgramParser;
+use num_bigint::BigUint;
+use num_traits::Num;
+use sierra2mlir::compile;
+use sierra2mlir::types::DEFAULT_PRIME;
+use test_case::test_case;
+
+// Tests behaviour of the generated MLIR against the behaviour of starkware's own sierra runner
+// Such tests must be an argumentless main function consisting of calls to the function in question
+
+#[test_case("id")]
+fn comparison_test(test_name: &str) -> Result<(), String> {
+    let sierra_code =
+        fs::read_to_string(&format!("./tests/comparison/{test_name}.sierra")).unwrap();
+    let llvm_result = run_sierra_via_llvm(test_name, &sierra_code)?;
+
+    let casm_result = run_sierra_via_casm(&sierra_code);
+
+    match casm_result {
+        Ok(result) => match result.value {
+            cairo_lang_runner::RunResultValue::Success(casm_values) => {
+                assert_eq!(
+                    casm_values.len(),
+                    llvm_result.len(),
+                    "Casm values and llvm values are of different lengths"
+                );
+                let prime = DEFAULT_PRIME.parse::<BigUint>().unwrap();
+                for i in 0..casm_values.len() {
+                    assert!(
+                        llvm_result[i] < prime,
+                        "Test no. {} of {} failed. {} >= PRIME. Expected {} (-{})",
+                        i + 1,
+                        test_name,
+                        llvm_result[i],
+                        casm_values[i],
+                        prime.clone() - casm_values[i].to_biguint()
+                    );
+                    assert_eq!(
+                        casm_values[i].to_biguint(),
+                        llvm_result[i],
+                        "Test no. {} of {} failed. {} != {} (-{} != -{})",
+                        i + 1,
+                        test_name,
+                        casm_values[i],
+                        llvm_result[i],
+                        prime.clone() - casm_values[i].to_biguint(),
+                        prime.clone() - llvm_result[i].clone()
+                    )
+                }
+            }
+            cairo_lang_runner::RunResultValue::Panic(_) => {
+                todo!("Comparison tests where the cairo runner panics");
+            }
+        },
+        Err(_) => {
+            todo!("Comparison tests where the cairo runner fails");
+        }
+    }
+    Ok(())
+}
+
+// Invokes starkware's runner that compiles sierra to casm and runs it
+// This provides us with the intended results to compare against
+fn run_sierra_via_casm(sierra_code: &str) -> Result<RunResult, anyhow::Error> {
+    let sierra_program = ProgramParser::new().parse(sierra_code).unwrap();
+
+    let runner = SierraCasmRunner::new(sierra_program, false)
+        .with_context(|| "Failed setting up runner.")?;
+
+    runner
+        .run_function("::main", &[], None)
+        .with_context(|| "Failed to run the function.")
+}
+
+// Runs the test file via compiling to mlir, then llir, then invoking lli to run it
+fn run_sierra_via_llvm(test_name: &str, sierra_code: &str) -> Result<Vec<BigUint>, String> {
+    let tmp_dir = tempdir::TempDir::new("test_comparison")
+        .unwrap()
+        .into_path();
+    let mlir_file = tmp_dir
+        .join(format!("{test_name}.mlir"))
+        .display()
+        .to_string();
+    let output_file = tmp_dir
+        .join(format!("{test_name}.ll"))
+        .display()
+        .to_string();
+
+    let compiled_code = compile(sierra_code, false, false).unwrap();
+    std::fs::write(mlir_file.as_str(), compiled_code).unwrap();
+
+    let mlir_prefix = std::env::var("MLIR_SYS_160_PREFIX").unwrap();
+    let mlir_translate_path = Path::new(mlir_prefix.as_str())
+        .join("bin")
+        .join("mlir-translate");
+    let lli_path = Path::new(mlir_prefix.as_str()).join("bin").join("lli");
+
+    let mlir_output = Command::new(mlir_translate_path)
+        .arg("--mlir-to-llvmir")
+        .arg("-o")
+        .arg(output_file.as_str())
+        .arg(mlir_file.as_str())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap()
+        .wait_with_output()
+        .unwrap();
+
+    if mlir_output.stdout.len() > 0 || mlir_output.stderr.len() > 0 {
+        println!(
+            "Mlir_output:\n    stdout: {}\n    stderr: {}",
+            String::from_utf8(mlir_output.stdout).unwrap(),
+            String::from_utf8(mlir_output.stderr).unwrap()
+        );
+    }
+
+    let lli_cmd = Command::new(lli_path)
+        .arg(output_file)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let lli_output = lli_cmd.wait_with_output().unwrap();
+
+    if lli_output.stderr.len() > 0 {
+        return Err(format!("lli failed with output: {}", String::from_utf8(lli_output.stderr).unwrap()));
+    }
+
+    let output = std::str::from_utf8(&lli_output.stdout).unwrap().trim();
+
+    return Ok(parse_llvm_result(output));
+}
+
+// Parses the human-readable output from running the llir code into a raw list of outputs
+fn parse_llvm_result(res: &str) -> Vec<BigUint> {
+    println!(
+        "Parsing llvm result: '{}', length: {}",
+        res,
+        res.chars().count()
+    );
+    return res
+        .split('\n')
+        .filter(|s| s.len() > 0)
+        .map(|x| BigUint::from_str_radix(x, 10).unwrap())
+        .collect();
+}

--- a/sierra2mlir/tests/comparison.rs
+++ b/sierra2mlir/tests/comparison.rs
@@ -14,7 +14,8 @@ use test_case::test_case;
 // Tests behaviour of the generated MLIR against the behaviour of starkware's own sierra runner
 // Such tests must be an argumentless main function consisting of calls to the function in question
 
-#[test_case("id")]
+#[test_case("simple_return")]
+#[test_case("tuple_return")]
 fn comparison_test(test_name: &str) -> Result<(), String> {
     let sierra_code =
         fs::read_to_string(&format!("./tests/comparison/{test_name}.sierra")).unwrap();
@@ -83,6 +84,7 @@ fn run_sierra_via_llvm(test_name: &str, sierra_code: &str) -> Result<Vec<BigUint
     let tmp_dir = tempdir::TempDir::new("test_comparison")
         .unwrap()
         .into_path();
+
     let mlir_file = tmp_dir
         .join(format!("{test_name}.mlir"))
         .display()
@@ -92,7 +94,7 @@ fn run_sierra_via_llvm(test_name: &str, sierra_code: &str) -> Result<Vec<BigUint
         .display()
         .to_string();
 
-    let compiled_code = compile(sierra_code, false, false).unwrap();
+    let compiled_code = compile(sierra_code, false, false, true).unwrap();
     std::fs::write(mlir_file.as_str(), compiled_code).unwrap();
 
     let mlir_prefix = std::env::var("MLIR_SYS_160_PREFIX").unwrap();
@@ -151,6 +153,6 @@ fn parse_llvm_result(res: &str) -> Vec<BigUint> {
     return res
         .split('\n')
         .filter(|s| s.len() > 0)
-        .map(|x| BigUint::from_str_radix(x, 10).unwrap())
+        .map(|x| BigUint::from_str_radix(x, 16).unwrap())
         .collect();
 }

--- a/sierra2mlir/tests/comparison.rs
+++ b/sierra2mlir/tests/comparison.rs
@@ -130,7 +130,10 @@ fn run_sierra_via_llvm(test_name: &str, sierra_code: &str) -> Result<Vec<BigUint
     let lli_output = lli_cmd.wait_with_output().unwrap();
 
     if lli_output.stderr.len() > 0 {
-        return Err(format!("lli failed with output: {}", String::from_utf8(lli_output.stderr).unwrap()));
+        return Err(format!(
+            "lli failed with output: {}",
+            String::from_utf8(lli_output.stderr).unwrap()
+        ));
     }
 
     let output = std::str::from_utf8(&lli_output.stdout).unwrap().trim();

--- a/sierra2mlir/tests/comparison.rs
+++ b/sierra2mlir/tests/comparison.rs
@@ -4,8 +4,8 @@ use std::process::{Command, Stdio};
 
 use cairo_lang_runner::{RunResult, SierraCasmRunner};
 use cairo_lang_sierra::ProgramParser;
-use color_eyre::Result;
 use color_eyre::eyre::WrapErr;
+use color_eyre::Result;
 use num_bigint::BigUint;
 use num_traits::Num;
 use sierra2mlir::compile;

--- a/sierra2mlir/tests/comparison/.gitignore
+++ b/sierra2mlir/tests/comparison/.gitignore
@@ -1,0 +1,2 @@
+# Until we can autogenerate the tests from cairo, ignore cairo files to prevent them getting out of sync
+*.cairo

--- a/sierra2mlir/tests/comparison/id.sierra
+++ b/sierra2mlir/tests/comparison/id.sierra
@@ -1,0 +1,10 @@
+type felt252 = felt252;
+
+libfunc felt252_const<10> = felt252_const<10>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+felt252_const<10>() -> ([0]);
+store_temp<felt252>([0]) -> ([1]);
+return([1]);
+
+id::id::main@0() -> (felt252);

--- a/sierra2mlir/tests/comparison/simple_return.sierra
+++ b/sierra2mlir/tests/comparison/simple_return.sierra
@@ -1,0 +1,10 @@
+type felt252 = felt252;
+
+libfunc felt252_const<10> = felt252_const<10>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+felt252_const<10>() -> ([0]);
+store_temp<felt252>([0]) -> ([1]);
+return([1]);
+
+simple_return::simple_return::main@0() -> (felt252);

--- a/sierra2mlir/tests/comparison/tuple_return.sierra
+++ b/sierra2mlir/tests/comparison/tuple_return.sierra
@@ -1,0 +1,15 @@
+type felt252 = felt252;
+type Tuple<felt252, felt252> = Struct<ut@Tuple, felt252, felt252>;
+
+libfunc felt252_const<10> = felt252_const<10>;
+libfunc felt252_const<11> = felt252_const<11>;
+libfunc struct_construct<Tuple<felt252, felt252>> = struct_construct<Tuple<felt252, felt252>>;
+libfunc store_temp<Tuple<felt252, felt252>> = store_temp<Tuple<felt252, felt252>>;
+
+felt252_const<10>() -> ([0]);
+felt252_const<11>() -> ([1]);
+struct_construct<Tuple<felt252, felt252>>([0], [1]) -> ([2]);
+store_temp<Tuple<felt252, felt252>>([2]) -> ([3]);
+return([3]);
+
+tuple_return::tuple_return::main@0() -> (Tuple<felt252, felt252>);


### PR DESCRIPTION
This adds the initial framework for tests that run sierra both via mlir and via starkware's cairo runner and compare the results. Could be changed to use the ExecutionEngine, but at that point I think it's worth making a PR to have the cli's run function get the result from the execution engine and return it and use that which imo should be a separate PR. The wrappers generated here would also be useful for that as they could be repurposed to return a vector/array/tensor of felts rather than printing it