### PR TITLE
update examples

### DIFF
--- a/examples/simple-optimized.ll
+++ b/examples/simple-optimized.ll
@@ -13,18 +13,20 @@ define internal { i256, i256 } @"dup<felt252>"(i256 %0) {
 
 define internal i256 @felt252_add(i256 %0, i256 %1) {
   %3 = sext i256 %0 to i512
-  %4 = add i512 %3, %3
-  %5 = srem i512 %4, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %6 = trunc i512 %5 to i256
-  ret i256 %6
+  %4 = sext i256 %1 to i512
+  %5 = add i512 %3, %4
+  %6 = srem i512 %5, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %7 = trunc i512 %6 to i256
+  ret i256 %7
 }
 
 define internal i256 @felt252_sub(i256 %0, i256 %1) {
   %3 = sext i256 %0 to i512
-  %4 = sub i512 %3, %3
-  %5 = srem i512 %4, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %6 = trunc i512 %5 to i256
-  ret i256 %6
+  %4 = sext i256 %1 to i512
+  %5 = sub i512 %3, %4
+  %6 = srem i512 %5, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %7 = trunc i512 %6 to i256
+  ret i256 %7
 }
 
 define internal { i256, i256 } @"struct_construct<Tuple<felt252, felt252>>"(i256 %0, i256 %1) {
@@ -38,16 +40,20 @@ define internal { i256, i256 } @"store_temp<Tuple<felt252, felt252>>"({ i256, i2
 }
 
 define { i256, i256 } @simple_simple_something(i256 %0) {
-  %2 = sext i256 %0 to i512
-  %3 = add i512 %2, %2
-  %4 = srem i512 %3, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %5 = trunc i512 %4 to i256
-  %6 = sub i512 %2, %2
-  %7 = srem i512 %6, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %8 = trunc i512 %7 to i256
-  %9 = insertvalue { i256, i256 } undef, i256 %5, 0
-  %10 = insertvalue { i256, i256 } %9, i256 %8, 1
-  ret { i256, i256 } %10
+  %2 = call { i256, i256 } @"dup<felt252>"(i256 %0)
+  %3 = extractvalue { i256, i256 } %2, 0
+  %4 = extractvalue { i256, i256 } %2, 1
+  %5 = call i256 @felt252_add(i256 %4, i256 2)
+  %6 = call i256 @felt252_sub(i256 %3, i256 2)
+  %7 = call { i256, i256 } @"struct_construct<Tuple<felt252, felt252>>"(i256 %5, i256 %6)
+  %8 = call { i256, i256 } @"store_temp<Tuple<felt252, felt252>>"({ i256, i256 } %7)
+  ret { i256, i256 } %8
+}
+
+define void @_mlir_ciface_simple_simple_something(ptr %0, i256 %1) {
+  %3 = call { i256, i256 } @simple_simple_something(i256 %1)
+  store { i256, i256 } %3, ptr %0, align 4
+  ret void
 }
 
 !llvm.module.flags = !{!0}

--- a/examples/simple-optimized.mlir
+++ b/examples/simple-optimized.mlir
@@ -8,18 +8,20 @@ module attributes {llvm.data_layout = ""} {
   llvm.func internal @felt252_add(%arg0: i256, %arg1: i256) -> i256 {
     %0 = llvm.mlir.constant(3618502788666131213697322783095070105623107215331596699973092056135872020481 : i512) : i512
     %1 = llvm.sext %arg0 : i256 to i512
-    %2 = llvm.add %1, %1  : i512
-    %3 = llvm.srem %2, %0  : i512
-    %4 = llvm.trunc %3 : i512 to i256
-    llvm.return %4 : i256
+    %2 = llvm.sext %arg1 : i256 to i512
+    %3 = llvm.add %1, %2  : i512
+    %4 = llvm.srem %3, %0  : i512
+    %5 = llvm.trunc %4 : i512 to i256
+    llvm.return %5 : i256
   }
   llvm.func internal @felt252_sub(%arg0: i256, %arg1: i256) -> i256 {
     %0 = llvm.mlir.constant(3618502788666131213697322783095070105623107215331596699973092056135872020481 : i512) : i512
     %1 = llvm.sext %arg0 : i256 to i512
-    %2 = llvm.sub %1, %1  : i512
-    %3 = llvm.srem %2, %0  : i512
-    %4 = llvm.trunc %3 : i512 to i256
-    llvm.return %4 : i256
+    %2 = llvm.sext %arg1 : i256 to i512
+    %3 = llvm.sub %1, %2  : i512
+    %4 = llvm.srem %3, %0  : i512
+    %5 = llvm.trunc %4 : i512 to i256
+    llvm.return %5 : i256
   }
   llvm.func internal @"struct_construct<Tuple<felt252, felt252>>"(%arg0: i256, %arg1: i256) -> !llvm.struct<(i256, i256)> {
     %0 = llvm.mlir.undef : !llvm.struct<(i256, i256)>
@@ -30,18 +32,20 @@ module attributes {llvm.data_layout = ""} {
   llvm.func internal @"store_temp<Tuple<felt252, felt252>>"(%arg0: !llvm.struct<(i256, i256)>) -> !llvm.struct<(i256, i256)> {
     llvm.return %arg0 : !llvm.struct<(i256, i256)>
   }
-  llvm.func @simple_simple_something(%arg0: i256) -> !llvm.struct<(i256, i256)> {
-    %0 = llvm.mlir.constant(3618502788666131213697322783095070105623107215331596699973092056135872020481 : i512) : i512
-    %1 = llvm.sext %arg0 : i256 to i512
-    %2 = llvm.add %1, %1  : i512
-    %3 = llvm.srem %2, %0  : i512
-    %4 = llvm.trunc %3 : i512 to i256
-    %5 = llvm.sub %1, %1  : i512
-    %6 = llvm.srem %5, %0  : i512
-    %7 = llvm.trunc %6 : i512 to i256
-    %8 = llvm.mlir.undef : !llvm.struct<(i256, i256)>
-    %9 = llvm.insertvalue %4, %8[0] : !llvm.struct<(i256, i256)> 
-    %10 = llvm.insertvalue %7, %9[1] : !llvm.struct<(i256, i256)> 
-    llvm.return %10 : !llvm.struct<(i256, i256)>
+  llvm.func @simple_simple_something(%arg0: i256) -> !llvm.struct<(i256, i256)> attributes {llvm.emit_c_interface} {
+    %0 = llvm.mlir.constant(2 : i256) : i256
+    %1 = llvm.call @"dup<felt252>"(%arg0) : (i256) -> !llvm.struct<(i256, i256)>
+    %2 = llvm.extractvalue %1[0] : !llvm.struct<(i256, i256)> 
+    %3 = llvm.extractvalue %1[1] : !llvm.struct<(i256, i256)> 
+    %4 = llvm.call @felt252_add(%3, %0) : (i256, i256) -> i256
+    %5 = llvm.call @felt252_sub(%2, %0) : (i256, i256) -> i256
+    %6 = llvm.call @"struct_construct<Tuple<felt252, felt252>>"(%4, %5) : (i256, i256) -> !llvm.struct<(i256, i256)>
+    %7 = llvm.call @"store_temp<Tuple<felt252, felt252>>"(%6) : (!llvm.struct<(i256, i256)>) -> !llvm.struct<(i256, i256)>
+    llvm.return %7 : !llvm.struct<(i256, i256)>
+  }
+  llvm.func @_mlir_ciface_simple_simple_something(%arg0: !llvm.ptr<struct<(i256, i256)>>, %arg1: i256) attributes {llvm.emit_c_interface} {
+    %0 = llvm.call @simple_simple_something(%arg1) : (i256) -> !llvm.struct<(i256, i256)>
+    llvm.store %0, %arg0 : !llvm.ptr<struct<(i256, i256)>>
+    llvm.return
   }
 }

--- a/examples/simple.ll
+++ b/examples/simple.ll
@@ -13,7 +13,7 @@ define internal { i256, i256 } @"dup<felt252>"(i256 %0) {
 
 define internal i256 @felt252_add(i256 %0, i256 %1) {
   %3 = sext i256 %0 to i512
-  %4 = sext i256 %0 to i512
+  %4 = sext i256 %1 to i512
   %5 = add i512 %3, %4
   %6 = srem i512 %5, 3618502788666131213697322783095070105623107215331596699973092056135872020481
   %7 = trunc i512 %6 to i256
@@ -22,7 +22,7 @@ define internal i256 @felt252_add(i256 %0, i256 %1) {
 
 define internal i256 @felt252_sub(i256 %0, i256 %1) {
   %3 = sext i256 %0 to i512
-  %4 = sext i256 %0 to i512
+  %4 = sext i256 %1 to i512
   %5 = sub i512 %3, %4
   %6 = srem i512 %5, 3618502788666131213697322783095070105623107215331596699973092056135872020481
   %7 = trunc i512 %6 to i256
@@ -48,6 +48,12 @@ define { i256, i256 } @simple_simple_something(i256 %0) {
   %7 = call { i256, i256 } @"struct_construct<Tuple<felt252, felt252>>"(i256 %5, i256 %6)
   %8 = call { i256, i256 } @"store_temp<Tuple<felt252, felt252>>"({ i256, i256 } %7)
   ret { i256, i256 } %8
+}
+
+define void @_mlir_ciface_simple_simple_something(ptr %0, i256 %1) {
+  %3 = call { i256, i256 } @simple_simple_something(i256 %1)
+  store { i256, i256 } %3, ptr %0, align 4
+  ret void
 }
 
 !llvm.module.flags = !{!0}

--- a/examples/simple.mlir
+++ b/examples/simple.mlir
@@ -7,7 +7,7 @@ module attributes {llvm.data_layout = ""} {
   }
   llvm.func internal @felt252_add(%arg0: i256, %arg1: i256) -> i256 {
     %0 = llvm.sext %arg0 : i256 to i512
-    %1 = llvm.sext %arg0 : i256 to i512
+    %1 = llvm.sext %arg1 : i256 to i512
     %2 = llvm.add %0, %1  : i512
     %3 = llvm.mlir.constant(3618502788666131213697322783095070105623107215331596699973092056135872020481 : i512) : i512
     %4 = llvm.srem %2, %3  : i512
@@ -16,7 +16,7 @@ module attributes {llvm.data_layout = ""} {
   }
   llvm.func internal @felt252_sub(%arg0: i256, %arg1: i256) -> i256 {
     %0 = llvm.sext %arg0 : i256 to i512
-    %1 = llvm.sext %arg0 : i256 to i512
+    %1 = llvm.sext %arg1 : i256 to i512
     %2 = llvm.sub %0, %1  : i512
     %3 = llvm.mlir.constant(3618502788666131213697322783095070105623107215331596699973092056135872020481 : i512) : i512
     %4 = llvm.srem %2, %3  : i512
@@ -32,7 +32,7 @@ module attributes {llvm.data_layout = ""} {
   llvm.func internal @"store_temp<Tuple<felt252, felt252>>"(%arg0: !llvm.struct<(i256, i256)>) -> !llvm.struct<(i256, i256)> {
     llvm.return %arg0 : !llvm.struct<(i256, i256)>
   }
-  llvm.func @simple_simple_something(%arg0: i256) -> !llvm.struct<(i256, i256)> {
+  llvm.func @simple_simple_something(%arg0: i256) -> !llvm.struct<(i256, i256)> attributes {llvm.emit_c_interface} {
     %0 = llvm.mlir.constant(2 : i256) : i256
     %1 = llvm.call @"dup<felt252>"(%arg0) : (i256) -> !llvm.struct<(i256, i256)>
     %2 = llvm.extractvalue %1[0] : !llvm.struct<(i256, i256)> 
@@ -43,5 +43,10 @@ module attributes {llvm.data_layout = ""} {
     %7 = llvm.call @"struct_construct<Tuple<felt252, felt252>>"(%4, %6) : (i256, i256) -> !llvm.struct<(i256, i256)>
     %8 = llvm.call @"store_temp<Tuple<felt252, felt252>>"(%7) : (!llvm.struct<(i256, i256)>) -> !llvm.struct<(i256, i256)>
     llvm.return %8 : !llvm.struct<(i256, i256)>
+  }
+  llvm.func @_mlir_ciface_simple_simple_something(%arg0: !llvm.ptr<struct<(i256, i256)>>, %arg1: i256) attributes {llvm.emit_c_interface} {
+    %0 = llvm.call @simple_simple_something(%arg1) : (i256) -> !llvm.struct<(i256, i256)>
+    llvm.store %0, %arg0 : !llvm.ptr<struct<(i256, i256)>>
+    llvm.return
   }
 }


### PR DESCRIPTION
updates the example compiled files (.ll and .mlir)

there is a `make build-examples` target that does this