### PR TITLE
clean type storage

### DIFF
--- a/sierra2mlir/src/libfuncs/mod.rs
+++ b/sierra2mlir/src/libfuncs/mod.rs
@@ -11,6 +11,14 @@ use crate::{
     statements::create_fn_signature,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
 impl<'ctx> Compiler<'ctx> {
     pub fn process_libfuncs(&'ctx self, storage: Rc<RefCell<Storage<'ctx>>>) -> Result<()> {
         for func_decl in &self.program.libfunc_declarations {
@@ -29,13 +37,28 @@ impl<'ctx> Compiler<'ctx> {
                     self.create_libfunc_felt_const(func_decl, &mut storage.borrow_mut());
                 }
                 "felt252_add" => {
-                    self.create_libfunc_felt_add(func_decl, parent_block, storage.clone())?;
+                    self.create_libfunc_felt_binary_op(
+                        func_decl,
+                        parent_block,
+                        storage.clone(),
+                        BinaryOp::Add,
+                    )?;
                 }
                 "felt252_sub" => {
-                    self.create_libfunc_felt_sub(func_decl, parent_block, storage.clone())?;
+                    self.create_libfunc_felt_binary_op(
+                        func_decl,
+                        parent_block,
+                        storage.clone(),
+                        BinaryOp::Sub,
+                    )?;
                 }
                 "felt252_mul" => {
-                    self.create_libfunc_felt_mul(func_decl, parent_block, storage.clone())?;
+                    self.create_libfunc_felt_binary_op(
+                        func_decl,
+                        parent_block,
+                        storage.clone(),
+                        BinaryOp::Mul,
+                    )?;
                 }
                 "dup" => {
                     self.create_libfunc_dup(func_decl, parent_block, storage.clone())?;
@@ -94,43 +117,37 @@ impl<'ctx> Compiler<'ctx> {
     ) -> Result<()> {
         let id = Self::normalize_func_name(func_decl.id.debug_name.as_ref().unwrap().as_str())
             .to_string();
-        let mut arg_types_with_locations = vec![];
+        let arg_type = match &func_decl.long_id.generic_args[0] {
+            GenericArg::UserType(_) => todo!(),
+            GenericArg::Type(type_id) => {
+                let storage = RefCell::borrow(&*storage);
+                let ty = storage
+                    .types
+                    .get(&type_id.id.to_string())
+                    .cloned()
+                    .expect("type to exist");
 
-        for arg in &func_decl.long_id.generic_args {
-            let storage = RefCell::borrow(&*storage);
-            match arg {
-                GenericArg::UserType(_) => todo!(),
-                GenericArg::Type(type_id) => {
-                    let ty = storage
-                        .types
-                        .get(&type_id.id.to_string())
-                        .expect("type to exist");
-
-                    let field_types = match ty {
-                        SierraType::Simple(_ty) => {
-                            unreachable!("struct construct shouldnt be called for simple types")
-                        }
-                        SierraType::Struct { ty: _, field_types } => field_types,
-                    };
-
-                    for ty in field_types {
-                        arg_types_with_locations.push((*ty, Location::unknown(&self.context)));
-                    }
-                }
-                GenericArg::Value(_) => todo!(),
-                GenericArg::UserFunc(_) => todo!(),
-                GenericArg::Libfunc(_) => todo!(),
+                ty
             }
-        }
+            GenericArg::Value(_) => todo!(),
+            GenericArg::UserFunc(_) => todo!(),
+            GenericArg::Libfunc(_) => todo!(),
+        };
+
+        let args = arg_type
+            .get_field_types()
+            .expect("arg should be a struct type and have field types");
+        let args_with_location = args
+            .iter()
+            .map(|x| (*x, Location::unknown(&self.context)))
+            .collect_vec();
 
         let region = Region::new();
 
-        let block = Block::new(&arg_types_with_locations);
+        let block = Block::new(&args_with_location);
 
-        let arg_types = arg_types_with_locations.iter().map(|x| x.0).collect_vec();
-        let struct_llvm_type = self.struct_type_string(&arg_types);
-        let mut struct_type_op = self.op_llvm_struct(&block, &arg_types);
-        //let mut struct_value: Value = struct_type_op.result(0)?.into();
+        let struct_llvm_type = self.struct_type_string(&args);
+        let mut struct_type_op = self.op_llvm_struct(&block, &args);
 
         for i in 0..block.argument_count() {
             let arg = block.argument(i)?;
@@ -143,7 +160,7 @@ impl<'ctx> Compiler<'ctx> {
         self.op_return(&block, &[struct_value]);
 
         let return_type = Type::parse(&self.context, &struct_llvm_type).unwrap();
-        let function_type = create_fn_signature(&arg_types, &[return_type]);
+        let function_type = create_fn_signature(&args, &[return_type]);
 
         region.append_block(block);
 
@@ -154,8 +171,8 @@ impl<'ctx> Compiler<'ctx> {
             storage.functions.insert(
                 id,
                 FunctionDef {
-                    args: arg_types,
-                    return_types: vec![return_type],
+                    args: arg_type.get_field_sierra_types().unwrap().to_vec(),
+                    return_types: vec![arg_type],
                 },
             );
         }
@@ -175,30 +192,29 @@ impl<'ctx> Compiler<'ctx> {
     ) -> Result<()> {
         let id = Self::normalize_func_name(func_decl.id.debug_name.as_ref().unwrap().as_str())
             .to_string();
-        let mut arg_types_with_locations = vec![];
 
-        for arg in &func_decl.long_id.generic_args {
-            let storage = RefCell::borrow(&*storage);
-            match arg {
-                GenericArg::UserType(_) => todo!(),
-                GenericArg::Type(type_id) => {
-                    let ty = storage
-                        .types
-                        .get(&type_id.id.to_string())
-                        .expect("type to exist");
+        let arg_type = match &func_decl.long_id.generic_args[0] {
+            GenericArg::UserType(_) => todo!(),
+            GenericArg::Type(type_id) => {
+                let storage = RefCell::borrow(&*storage);
+                let ty = storage
+                    .types
+                    .get(&type_id.id.to_string())
+                    .expect("type to exist");
 
-                    arg_types_with_locations
-                        .push((*ty.get_type(), Location::unknown(&self.context)));
-                }
-                GenericArg::Value(_) => todo!(),
-                GenericArg::UserFunc(_) => todo!(),
-                GenericArg::Libfunc(_) => todo!(),
+                ty.clone()
             }
-        }
+            GenericArg::Value(_) => todo!(),
+            GenericArg::UserFunc(_) => todo!(),
+            GenericArg::Libfunc(_) => todo!(),
+        };
 
         let region = Region::new();
 
-        let block = Block::new(&arg_types_with_locations);
+        let args = &[arg_type.get_type()];
+        let args_with_location = &[arg_type.get_type_location(&self.context)];
+
+        let block = Block::new(args_with_location);
 
         let mut results: Vec<Value> = vec![];
 
@@ -211,12 +227,7 @@ impl<'ctx> Compiler<'ctx> {
 
         region.append_block(block);
 
-        let arg_types = arg_types_with_locations
-            .iter()
-            .map(|(t, _)| *t)
-            .collect_vec();
-
-        let function_type = create_fn_signature(&arg_types, &arg_types);
+        let function_type = create_fn_signature(args, args);
 
         let func = self.op_func(&id, &function_type, vec![region], false, false)?;
 
@@ -225,8 +236,8 @@ impl<'ctx> Compiler<'ctx> {
             storage.functions.insert(
                 id,
                 FunctionDef {
-                    args: arg_types.clone(),
-                    return_types: arg_types,
+                    args: vec![arg_type.clone()],
+                    return_types: vec![arg_type],
                 },
             );
         }
@@ -244,30 +255,28 @@ impl<'ctx> Compiler<'ctx> {
     ) -> Result<()> {
         let id = Self::normalize_func_name(func_decl.id.debug_name.as_ref().unwrap().as_str())
             .to_string();
-        let mut arg_types_with_locations = vec![];
+        let arg_type = match &func_decl.long_id.generic_args[0] {
+            GenericArg::UserType(_) => todo!(),
+            GenericArg::Type(type_id) => {
+                let storage = RefCell::borrow(&*storage);
+                let ty = storage
+                    .types
+                    .get(&type_id.id.to_string())
+                    .expect("type to exist");
 
-        for arg in &func_decl.long_id.generic_args {
-            let storage = RefCell::borrow(&*storage);
-            match arg {
-                GenericArg::UserType(_) => todo!(),
-                GenericArg::Type(type_id) => {
-                    let ty = storage
-                        .types
-                        .get(&type_id.id.to_string())
-                        .expect("type to exist");
-
-                    arg_types_with_locations
-                        .push((*ty.get_type(), Location::unknown(&self.context)));
-                }
-                GenericArg::Value(_) => todo!(),
-                GenericArg::UserFunc(_) => todo!(),
-                GenericArg::Libfunc(_) => todo!(),
+                ty.clone()
             }
-        }
+            GenericArg::Value(_) => todo!(),
+            GenericArg::UserFunc(_) => todo!(),
+            GenericArg::Libfunc(_) => todo!(),
+        };
 
         let region = Region::new();
 
-        let block = Block::new(&arg_types_with_locations);
+        let args = &[arg_type.get_type()];
+        let args_with_location = &[arg_type.get_type_location(&self.context)];
+
+        let block = Block::new(args_with_location);
 
         // Return the results, 2 times.
         let mut results: Vec<Value> = vec![];
@@ -287,16 +296,11 @@ impl<'ctx> Compiler<'ctx> {
 
         region.append_block(block);
 
-        let arg_types = arg_types_with_locations
-            .iter()
-            .map(|(t, _)| *t)
-            .collect::<Vec<_>>();
+        let mut return_types = Vec::with_capacity(args.len() * 2);
+        return_types.extend_from_slice(args);
+        return_types.extend_from_slice(args);
 
-        let mut return_types = Vec::with_capacity(arg_types.len() * 2);
-        return_types.extend_from_slice(&arg_types);
-        return_types.extend_from_slice(&arg_types);
-
-        let function_type = create_fn_signature(&arg_types, &return_types);
+        let function_type = create_fn_signature(args, &return_types);
 
         let func = self.op_func(&id, &function_type, vec![region], false, false)?;
 
@@ -305,8 +309,8 @@ impl<'ctx> Compiler<'ctx> {
             storage.functions.insert(
                 id,
                 FunctionDef {
-                    args: arg_types,
-                    return_types,
+                    args: vec![arg_type.clone()],
+                    return_types: vec![arg_type.clone(), arg_type],
                 },
             );
         }
@@ -316,19 +320,22 @@ impl<'ctx> Compiler<'ctx> {
         Ok(())
     }
 
-    pub fn create_libfunc_felt_add(
+    pub fn create_libfunc_felt_binary_op(
         &'ctx self,
         func_decl: &LibfuncDeclaration,
         parent_block: BlockRef<'ctx>,
         storage: Rc<RefCell<Storage<'ctx>>>,
+        binary_op: BinaryOp,
     ) -> Result<()> {
         let id = Self::normalize_func_name(func_decl.id.debug_name.as_ref().unwrap().as_str())
             .to_string();
-        let felt_type = self.felt_type();
-        let loc = Location::unknown(&self.context);
+        let sierra_felt_type = SierraType::Simple(self.felt_type());
+        let felt_type = sierra_felt_type.get_type();
+        let felt_type_location = sierra_felt_type.get_type_location(&self.context);
+        dbg!(func_decl);
 
         let region = Region::new();
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
+        let block = Block::new(&[felt_type_location, felt_type_location]);
 
         let lhs_arg = block.argument(0)?;
         let rhs_arg = block.argument(1)?;
@@ -339,7 +346,12 @@ impl<'ctx> Compiler<'ctx> {
         let rhs_ext = self.op_sext(&block, rhs_arg.into(), self.double_felt_type());
         let rhs = rhs_ext.result(0)?;
 
-        let res = self.op_add(&block, lhs.into(), rhs.into());
+        let res = match binary_op {
+            BinaryOp::Add => self.op_add(&block, lhs.into(), rhs.into()),
+            BinaryOp::Sub => self.op_sub(&block, lhs.into(), rhs.into()),
+            BinaryOp::Mul => self.op_mul(&block, lhs.into(), rhs.into()),
+            BinaryOp::Div => todo!(),
+        };
         let res_result = res.result(0)?;
 
         let res = self.op_felt_modulo(&block, res_result.into())?;
@@ -360,114 +372,8 @@ impl<'ctx> Compiler<'ctx> {
         storage.borrow_mut().functions.insert(
             id,
             FunctionDef {
-                args: vec![felt_type, felt_type],
-                return_types: vec![felt_type],
-            },
-        );
-
-        parent_block.append_operation(func);
-        Ok(())
-    }
-
-    pub fn create_libfunc_felt_sub(
-        &'ctx self,
-        func_decl: &LibfuncDeclaration,
-        parent_block: BlockRef<'ctx>,
-        storage: Rc<RefCell<Storage<'ctx>>>,
-    ) -> Result<()> {
-        let id = Self::normalize_func_name(func_decl.id.debug_name.as_ref().unwrap().as_str())
-            .to_string();
-        let felt_type = self.felt_type();
-        let loc = Location::unknown(&self.context);
-
-        let region = Region::new();
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-
-        let lhs_arg = block.argument(0)?;
-        let rhs_arg = block.argument(1)?;
-
-        let lhs_ext = self.op_sext(&block, lhs_arg.into(), self.double_felt_type());
-        let lhs = lhs_ext.result(0)?;
-
-        let rhs_ext = self.op_sext(&block, rhs_arg.into(), self.double_felt_type());
-        let rhs = rhs_ext.result(0)?;
-
-        let res = self.op_sub(&block, lhs.into(), rhs.into());
-        let res_result = res.result(0)?;
-
-        let res = self.op_felt_modulo(&block, res_result.into())?;
-        let res_result = res.result(0)?;
-
-        self.op_return(&block, &[res_result.into()]);
-
-        region.append_block(block);
-
-        let func = self.op_func(
-            &id,
-            &format!("({felt_type}, {felt_type}) -> {felt_type}"),
-            vec![region],
-            false,
-            false,
-        )?;
-
-        storage.borrow_mut().functions.insert(
-            id,
-            FunctionDef {
-                args: vec![felt_type, felt_type],
-                return_types: vec![felt_type],
-            },
-        );
-
-        parent_block.append_operation(func);
-        Ok(())
-    }
-
-    pub fn create_libfunc_felt_mul(
-        &'ctx self,
-        func_decl: &LibfuncDeclaration,
-        parent_block: BlockRef<'ctx>,
-        storage: Rc<RefCell<Storage<'ctx>>>,
-    ) -> Result<()> {
-        let id = Self::normalize_func_name(func_decl.id.debug_name.as_ref().unwrap().as_str())
-            .to_string();
-        let felt_type = self.felt_type();
-        let loc = Location::unknown(&self.context);
-
-        let region = Region::new();
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-
-        let lhs_arg = block.argument(0)?;
-        let rhs_arg = block.argument(1)?;
-
-        let lhs_ext = self.op_sext(&block, lhs_arg.into(), self.double_felt_type());
-        let lhs = lhs_ext.result(0)?;
-
-        let rhs_ext = self.op_sext(&block, rhs_arg.into(), self.double_felt_type());
-        let rhs = rhs_ext.result(0)?;
-
-        let res = self.op_mul(&block, lhs.into(), rhs.into());
-        let res_result = res.result(0)?;
-
-        let res = self.op_felt_modulo(&block, res_result.into())?;
-        let res_result = res.result(0)?;
-
-        self.op_return(&block, &[res_result.into()]);
-
-        region.append_block(block);
-
-        let func = self.op_func(
-            &id,
-            &format!("({felt_type}, {felt_type}) -> {felt_type}"),
-            vec![region],
-            false,
-            false,
-        )?;
-
-        storage.borrow_mut().functions.insert(
-            id,
-            FunctionDef {
-                args: vec![felt_type, felt_type],
-                return_types: vec![felt_type],
+                args: vec![sierra_felt_type.clone(), sierra_felt_type.clone()],
+                return_types: vec![sierra_felt_type],
             },
         );
 

--- a/sierra2mlir/src/statements/mod.rs
+++ b/sierra2mlir/src/statements/mod.rs
@@ -84,7 +84,6 @@ impl<'ctx> Compiler<'ctx> {
                 let ty = storage
                     .types
                     .get(&param.ty.id.to_string())
-                    .clone()
                     .expect("type for param should exist");
 
                 param_types.push(ty.get_type());

--- a/sierra2mlir/src/statements/mod.rs
+++ b/sierra2mlir/src/statements/mod.rs
@@ -64,7 +64,7 @@ impl<'c> Variable<'c> {
 
 impl<'ctx> Compiler<'ctx> {
     #[allow(clippy::cognitive_complexity)]
-    pub fn process_functions(&self, storage: Rc<RefCell<Storage<'ctx>>>) -> Result<()> {
+    pub fn process_functions(&self, storage_cell: Rc<RefCell<Storage<'ctx>>>) -> Result<()> {
         for func in &self.program.funcs {
             debug!(?func, "processing func");
 
@@ -78,15 +78,16 @@ impl<'ctx> Compiler<'ctx> {
             let mut return_types = vec![];
             let mut return_sierra_types = vec![];
 
-            let storage = storage.borrow();
+            let storage = storage_cell.borrow();
 
             for param in &func.params {
                 let ty = storage
                     .types
                     .get(&param.ty.id.to_string())
+                    .clone()
                     .expect("type for param should exist");
 
-                param_types.push(*ty.get_type());
+                param_types.push(ty.get_type());
             }
             let param_types = param_types;
 
@@ -97,8 +98,8 @@ impl<'ctx> Compiler<'ctx> {
                     .expect("type for param should exist")
                     .get_type();
 
-                return_types.push(*ty);
-                return_sierra_types.push((*ty, ret.clone()));
+                return_types.push(ty);
+                return_sierra_types.push((ty, ret.clone()));
             }
             let return_sierra_types = return_sierra_types;
             let return_types = return_types;
@@ -322,12 +323,18 @@ impl<'ctx> Compiler<'ctx> {
                                         args.push(res);
                                     }
 
+                                    let return_types = func_def
+                                        .return_types
+                                        .iter()
+                                        .map(|x| x.get_type())
+                                        .collect_vec();
+
                                     debug!(id, "creating func call");
                                     let op = self.op_func_call(
                                         current_block,
                                         &id,
                                         &args,
-                                        &func_def.return_types,
+                                        &return_types,
                                     )?;
                                     debug!("created");
 
@@ -377,7 +384,7 @@ impl<'ctx> Compiler<'ctx> {
                     &name,
                     &param_types,
                     &return_sierra_types,
-                    storage,
+                    storage_cell.borrow(),
                 )?;
             }
         }

--- a/sierra2mlir/src/types/mod.rs
+++ b/sierra2mlir/src/types/mod.rs
@@ -43,13 +43,7 @@ impl<'ctx> Compiler<'ctx> {
                         let ty = &types[0];
                         storage.types.insert(id.to_string(), ty.clone());
                     } else {
-                        let struct_types = types
-                            .iter()
-                            .map(|ty| match ty {
-                                SierraType::Simple(ty) => *ty,
-                                SierraType::Struct { ty, field_types: _ } => *ty,
-                            })
-                            .collect_vec();
+                        let struct_types = types.iter().map(SierraType::get_type).collect_vec();
                         let struct_type =
                             Type::parse(&self.context, &self.struct_type_string(&struct_types))
                                 .unwrap();
@@ -58,7 +52,7 @@ impl<'ctx> Compiler<'ctx> {
                             id.to_string(),
                             SierraType::Struct {
                                 ty: struct_type,
-                                field_types: struct_types,
+                                field_types: types,
                             },
                         );
                     }
@@ -88,13 +82,7 @@ impl<'ctx> Compiler<'ctx> {
                         types.push(gen_arg_ty.clone());
                     }
 
-                    let struct_types = types
-                        .iter()
-                        .map(|ty| match ty {
-                            SierraType::Simple(ty) => *ty,
-                            SierraType::Struct { ty, field_types: _ } => *ty,
-                        })
-                        .collect_vec();
+                    let struct_types = types.iter().map(SierraType::get_type).collect_vec();
                     let struct_type =
                         Type::parse(&self.context, &self.struct_type_string(&struct_types))
                             .unwrap();
@@ -103,7 +91,7 @@ impl<'ctx> Compiler<'ctx> {
                         id.to_string(),
                         SierraType::Struct {
                             ty: struct_type,
-                            field_types: struct_types,
+                            field_types: types,
                         },
                     );
                 }

--- a/sierra2mlir/tests/comparison.rs
+++ b/sierra2mlir/tests/comparison.rs
@@ -41,7 +41,7 @@ fn comparison_test(test_name: &str) -> Result<(), String> {
                         test_name,
                         llvm_result[i],
                         casm_values[i],
-                        prime.clone() - casm_values[i].to_biguint()
+                        prime - casm_values[i].to_biguint()
                     );
                     assert_eq!(
                         casm_values[i].to_biguint(),
@@ -52,7 +52,7 @@ fn comparison_test(test_name: &str) -> Result<(), String> {
                         casm_values[i],
                         llvm_result[i],
                         prime.clone() - casm_values[i].to_biguint(),
-                        prime.clone() - llvm_result[i].clone()
+                        prime - llvm_result[i].clone()
                     )
                 }
             }
@@ -116,7 +116,7 @@ fn run_sierra_via_llvm(test_name: &str, sierra_code: &str) -> Result<Vec<BigUint
         .wait_with_output()
         .unwrap();
 
-    if mlir_output.stdout.len() > 0 || mlir_output.stderr.len() > 0 {
+    if !mlir_output.stdout.is_empty() || !mlir_output.stderr.is_empty() {
         println!(
             "Mlir_output:\n    stdout: {}\n    stderr: {}",
             String::from_utf8(mlir_output.stdout).unwrap(),
@@ -132,7 +132,7 @@ fn run_sierra_via_llvm(test_name: &str, sierra_code: &str) -> Result<Vec<BigUint
         .unwrap();
     let lli_output = lli_cmd.wait_with_output().unwrap();
 
-    if lli_output.stderr.len() > 0 {
+    if !lli_output.stderr.is_empty() {
         return Err(format!(
             "lli failed with output: {}",
             String::from_utf8(lli_output.stderr).unwrap()
@@ -141,7 +141,7 @@ fn run_sierra_via_llvm(test_name: &str, sierra_code: &str) -> Result<Vec<BigUint
 
     let output = std::str::from_utf8(&lli_output.stdout).unwrap().trim();
 
-    return Ok(parse_llvm_result(output));
+    Ok(parse_llvm_result(output))
 }
 
 // Parses the human-readable output from running the llir code into a raw list of outputs
@@ -153,7 +153,7 @@ fn parse_llvm_result(res: &str) -> Vec<BigUint> {
     );
     return res
         .split('\n')
-        .filter(|s| s.len() > 0)
+        .filter(|s| !s.is_empty())
         .map(|x| BigUint::from_str_radix(x, 16).unwrap())
         .collect();
 }


### PR DESCRIPTION
Always stores the types as SierraTypes, holding all the information instead of just the Type, and losing info such as field types in structs.

This will allow us to implement some things better in the future, such as enums i think, it also feels nicer.

I also removed repeated code for the add,sub,mul