### PR TITLE
pin cairo commit, fix tests due to cairo update

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 sierra2mlir = { version = "0.1.0", path = "../sierra2mlir" }
-clap = { version = "4.1.11", features = ["derive"] }
+clap = { version = "4.1.13", features = ["derive"] }
 color-eyre = "0.6.2"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/sierra2mlir/Cargo.toml
+++ b/sierra2mlir/Cargo.toml
@@ -13,15 +13,15 @@ name = "execution"
 harness = false
 
 [dependencies]
-cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", rev = "3940e095b5953881216916c92534903e8f07678b"}
 tracing = "0.1.37"
 color-eyre = "0.6.2"
 melior-next = { git = "https://github.com/edg-l/melior-next", rev = "33d89f76a742bdc7c211b07df307688f6411a40c"}
 itertools = "0.10.5"
-regex = "1.7.1"
+regex = "1.7.3"
 
 [dev-dependencies]
-cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo", rev = "3940e095b5953881216916c92534903e8f07678b" }
 criterion = "0.4.0"
 num-bigint = "0.4.3"
 num-traits = "0.2.15"

--- a/sierra2mlir/tests/comparison.rs
+++ b/sierra2mlir/tests/comparison.rs
@@ -72,8 +72,8 @@ fn comparison_test(test_name: &str) -> Result<(), String> {
 fn run_sierra_via_casm(sierra_code: &str) -> Result<RunResult> {
     let sierra_program = ProgramParser::new().parse(sierra_code).unwrap();
 
-    let runner = SierraCasmRunner::new(sierra_program, false)
-        .with_context(|| "Failed setting up runner.")?;
+    let runner =
+        SierraCasmRunner::new(sierra_program, None).with_context(|| "Failed setting up runner.")?;
 
     runner
         .run_function("::main", &[], None)


### PR DESCRIPTION
Since cairo is moving at a fast pace, it's better to pin the revision so local lock files are what we expect, otherwise ci might run a newer commit. Giving unexpected results