### PR TITLE
update ci checkout to version 3 to avoid ci warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       MLIR_SYS_160_PREFIX: /usr/lib/llvm-16
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -44,7 +44,7 @@ jobs:
       MLIR_SYS_160_PREFIX: /usr/lib/llvm-16
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup rust env
         uses: actions-rs/toolchain@v1
         with:
@@ -70,7 +70,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -90,7 +90,7 @@ jobs:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       RUSTUP_TOOLCHAIN: nightly
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         name: "Rust Toolchain Setup"
         with:
@@ -118,6 +118,6 @@ jobs:
     steps:
       - name: Install deps
         run: sudo apt-get install curl ripgrep jq
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check cairo release
         run: bash .github/scripts/check-git-deps.sh '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,10 @@ jobs:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
           components: clippy
       - uses: Swatinem/rust-cache@v2
-
       - name: add llvm deb repository
         uses: myci-actions/add-deb-repo@10
         with:
@@ -31,11 +28,8 @@ jobs:
           keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
       - name: Install LLVM
         run: sudo apt-get install libllvm-16-ocaml-dev libllvm16 llvm-16 llvm-16-dev llvm-16-doc llvm-16-examples llvm-16-runtime clang-16 clang-tools-16 clang-16-doc libclang-common-16-dev libclang-16-dev libclang1-16 lld-16 libpolly-16-dev libclang-rt-16-dev libc++-16-dev libc++abi-16-dev libmlir-16-dev mlir-16-tools
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all --all-targets -- -D warnings
+      - name: Clippy
+        run: cargo clippy --all --all-targets -- -D warnings
 
   test:
     name: test
@@ -46,12 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust env
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Retreive cached dependecies
         uses: Swatinem/rust-cache@v2
-
       - name: add llvm deb repository
         uses: myci-actions/add-deb-repo@10
         with:
@@ -60,27 +51,18 @@ jobs:
           keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
       - name: Install LLVM
         run: sudo apt-get install libllvm-16-ocaml-dev libllvm16 llvm-16 llvm-16-dev llvm-16-doc llvm-16-examples llvm-16-runtime clang-16 clang-tools-16 clang-16-doc libclang-common-16-dev libclang-16-dev libclang1-16 lld-16 libpolly-16-dev libclang-rt-16-dev libc++-16-dev libc++abi-16-dev libmlir-16-dev mlir-16-tools
+      - name: cargo test
+        run: cargo test --all
 
-      - run: cargo test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           components: rustfmt
-          toolchain: stable
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   # Check for unnecessary dependencies.
   udeps:
@@ -91,11 +73,9 @@ jobs:
       RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        name: "Rust Toolchain Setup"
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
 
       - name: add llvm deb repository


### PR DESCRIPTION
also uses https://github.com/dtolnay/rust-toolchain

instead of the outdated (2021) action-rs actions