### PR TITLE
Implement `u???_to_felt252` libfuncs.

### DIFF
--- a/examples/uint.cairo
+++ b/examples/uint.cairo
@@ -1,0 +1,19 @@
+use integer::u8_to_felt252;
+use integer::u16_to_felt252;
+use integer::u32_to_felt252;
+use integer::u64_to_felt252;
+use integer::u128_to_felt252;
+
+fn main() {
+    let u8_value = 0_u8;
+    let u16_value = 0_u16;
+    let u32_value = 0_u32;
+    let u64_value = 0_u64;
+    let u128_value = 0_u128;
+
+    let u8_felt: felt252 = u8_to_felt252(u8_value);
+    let u16_felt: felt252 = u16_to_felt252(u16_value);
+    let u32_felt: felt252 = u32_to_felt252(u32_value);
+    let u64_felt: felt252 = u64_to_felt252(u64_value);
+    let u128_felt: felt252 = u128_to_felt252(u128_value);
+}

--- a/examples/uint.sierra
+++ b/examples/uint.sierra
@@ -1,0 +1,42 @@
+type u8 = u8;
+type u16 = u16;
+type u32 = u32;
+type u64 = u64;
+type u128 = u128;
+type felt252 = felt252;
+type Unit = Struct<ut@Tuple>;
+
+libfunc u8_const<0> = u8_const<0>;
+libfunc u16_const<0> = u16_const<0>;
+libfunc u32_const<0> = u32_const<0>;
+libfunc u64_const<0> = u64_const<0>;
+libfunc u128_const<0> = u128_const<0>;
+libfunc u8_to_felt252 = u8_to_felt252;
+libfunc drop<felt252> = drop<felt252>;
+libfunc u16_to_felt252 = u16_to_felt252;
+libfunc u32_to_felt252 = u32_to_felt252;
+libfunc u64_to_felt252 = u64_to_felt252;
+libfunc u128_to_felt252 = u128_to_felt252;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc store_temp<Unit> = store_temp<Unit>;
+
+u8_const<0>() -> ([0]);
+u16_const<0>() -> ([1]);
+u32_const<0>() -> ([2]);
+u64_const<0>() -> ([3]);
+u128_const<0>() -> ([4]);
+u8_to_felt252([0]) -> ([5]);
+drop<felt252>([5]) -> ();
+u16_to_felt252([1]) -> ([6]);
+drop<felt252>([6]) -> ();
+u32_to_felt252([2]) -> ([7]);
+drop<felt252>([7]) -> ();
+u64_to_felt252([3]) -> ([8]);
+drop<felt252>([8]) -> ();
+u128_to_felt252([4]) -> ([9]);
+drop<felt252>([9]) -> ();
+struct_construct<Unit>() -> ([10]);
+store_temp<Unit>([10]) -> ([11]);
+return([11]);
+
+uint::uint::main@0() -> (Unit);

--- a/sierra2mlir/src/libfuncs/mod.rs
+++ b/sierra2mlir/src/libfuncs/mod.rs
@@ -101,6 +101,41 @@ impl<'ctx> Compiler<'ctx> {
                 "u128_const" => {
                     self.create_libfunc_u128_const(func_decl, storage.clone());
                 }
+                "u8_to_felt252" => {
+                    self.create_libfunc_u8_to_felt252(
+                        func_decl,
+                        parent_block,
+                        &mut storage.borrow_mut(),
+                    )?;
+                }
+                "u16_to_felt252" => {
+                    self.create_libfunc_u16_to_felt252(
+                        func_decl,
+                        parent_block,
+                        &mut storage.borrow_mut(),
+                    )?;
+                }
+                "u32_to_felt252" => {
+                    self.create_libfunc_u32_to_felt252(
+                        func_decl,
+                        parent_block,
+                        &mut storage.borrow_mut(),
+                    )?;
+                }
+                "u64_to_felt252" => {
+                    self.create_libfunc_u64_to_felt252(
+                        func_decl,
+                        parent_block,
+                        &mut storage.borrow_mut(),
+                    )?;
+                }
+                "u128_to_felt252" => {
+                    self.create_libfunc_u128_to_felt252(
+                        func_decl,
+                        parent_block,
+                        &mut storage.borrow_mut(),
+                    )?;
+                }
                 "bitwise" => {
                     self.create_libfunc_bitwise(
                         func_decl,
@@ -640,6 +675,181 @@ impl<'ctx> Compiler<'ctx> {
             Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned(),
             arg,
         );
+    }
+
+    pub fn create_libfunc_u8_to_felt252(
+        &'ctx self,
+        func_decl: &LibfuncDeclaration,
+        parent_block: BlockRef<'ctx>,
+        storage: &mut Storage<'ctx>,
+    ) -> Result<()> {
+        let region = Region::new();
+        let block =
+            region.append_block(Block::new(&[(self.u8_type(), Location::unknown(&self.context))]));
+
+        let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
+        self.op_return(&block, &[op_zext.result(0)?.into()]);
+
+        let id =
+            Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
+        let func = self.op_func(
+            &id,
+            &create_fn_signature(&[self.u8_type()], &[self.felt_type()]),
+            vec![region],
+            false,
+            false,
+        )?;
+
+        storage.libfuncs.insert(
+            id,
+            FunctionDef {
+                args: vec![SierraType::Simple(self.u8_type())],
+                return_types: vec![SierraType::Simple(self.felt_type())],
+            },
+        );
+        parent_block.append_operation(func);
+
+        Ok(())
+    }
+
+    pub fn create_libfunc_u16_to_felt252(
+        &'ctx self,
+        func_decl: &LibfuncDeclaration,
+        parent_block: BlockRef<'ctx>,
+        storage: &mut Storage<'ctx>,
+    ) -> Result<()> {
+        let region = Region::new();
+        let block =
+            region.append_block(Block::new(&[(self.u16_type(), Location::unknown(&self.context))]));
+
+        let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
+        self.op_return(&block, &[op_zext.result(0)?.into()]);
+
+        let id =
+            Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
+        let func = self.op_func(
+            &id,
+            &create_fn_signature(&[self.u16_type()], &[self.felt_type()]),
+            vec![region],
+            false,
+            false,
+        )?;
+
+        storage.libfuncs.insert(
+            id,
+            FunctionDef {
+                args: vec![SierraType::Simple(self.u16_type())],
+                return_types: vec![SierraType::Simple(self.felt_type())],
+            },
+        );
+        parent_block.append_operation(func);
+
+        Ok(())
+    }
+
+    pub fn create_libfunc_u32_to_felt252(
+        &'ctx self,
+        func_decl: &LibfuncDeclaration,
+        parent_block: BlockRef<'ctx>,
+        storage: &mut Storage<'ctx>,
+    ) -> Result<()> {
+        let region = Region::new();
+        let block =
+            region.append_block(Block::new(&[(self.u32_type(), Location::unknown(&self.context))]));
+
+        let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
+        self.op_return(&block, &[op_zext.result(0)?.into()]);
+
+        let id =
+            Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
+        let func = self.op_func(
+            &id,
+            &create_fn_signature(&[self.u32_type()], &[self.felt_type()]),
+            vec![region],
+            false,
+            false,
+        )?;
+
+        storage.libfuncs.insert(
+            id,
+            FunctionDef {
+                args: vec![SierraType::Simple(self.u32_type())],
+                return_types: vec![SierraType::Simple(self.felt_type())],
+            },
+        );
+        parent_block.append_operation(func);
+
+        Ok(())
+    }
+
+    pub fn create_libfunc_u64_to_felt252(
+        &'ctx self,
+        func_decl: &LibfuncDeclaration,
+        parent_block: BlockRef<'ctx>,
+        storage: &mut Storage<'ctx>,
+    ) -> Result<()> {
+        let region = Region::new();
+        let block =
+            region.append_block(Block::new(&[(self.u64_type(), Location::unknown(&self.context))]));
+
+        let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
+        self.op_return(&block, &[op_zext.result(0)?.into()]);
+
+        let id =
+            Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
+        let func = self.op_func(
+            &id,
+            &create_fn_signature(&[self.u64_type()], &[self.felt_type()]),
+            vec![region],
+            false,
+            false,
+        )?;
+
+        storage.libfuncs.insert(
+            id,
+            FunctionDef {
+                args: vec![SierraType::Simple(self.u64_type())],
+                return_types: vec![SierraType::Simple(self.felt_type())],
+            },
+        );
+        parent_block.append_operation(func);
+
+        Ok(())
+    }
+
+    pub fn create_libfunc_u128_to_felt252(
+        &'ctx self,
+        func_decl: &LibfuncDeclaration,
+        parent_block: BlockRef<'ctx>,
+        storage: &mut Storage<'ctx>,
+    ) -> Result<()> {
+        let region = Region::new();
+        let block = region
+            .append_block(Block::new(&[(self.u128_type(), Location::unknown(&self.context))]));
+
+        let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
+        self.op_return(&block, &[op_zext.result(0)?.into()]);
+
+        let id =
+            Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
+        let func = self.op_func(
+            &id,
+            &create_fn_signature(&[self.u128_type()], &[self.felt_type()]),
+            vec![region],
+            false,
+            false,
+        )?;
+
+        storage.libfuncs.insert(
+            id,
+            FunctionDef {
+                args: vec![SierraType::Simple(self.u128_type())],
+                return_types: vec![SierraType::Simple(self.felt_type())],
+            },
+        );
+        parent_block.append_operation(func);
+
+        Ok(())
     }
 
     pub fn create_libfunc_bitwise(

--- a/sierra2mlir/src/libfuncs/mod.rs
+++ b/sierra2mlir/src/libfuncs/mod.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, cmp::Ordering, rc::Rc};
 use cairo_lang_sierra::program::{GenericArg, LibfuncDeclaration};
 use color_eyre::Result;
 use itertools::Itertools;
-use melior_next::ir::{Block, BlockRef, Location, Region, TypeLike, Value};
+use melior_next::ir::{Block, BlockRef, Location, Region, Type, TypeLike, Value};
 use tracing::debug;
 
 use crate::{
@@ -107,38 +107,43 @@ impl<'ctx> Compiler<'ctx> {
                     self.create_libfunc_u128_const(func_decl, storage.clone());
                 }
                 "u8_to_felt252" => {
-                    self.create_libfunc_u8_to_felt252(
+                    self.create_libfunc_uint_to_felt252(
                         func_decl,
                         parent_block,
                         &mut storage.borrow_mut(),
+                        self.u8_type(),
                     )?;
                 }
                 "u16_to_felt252" => {
-                    self.create_libfunc_u16_to_felt252(
+                    self.create_libfunc_uint_to_felt252(
                         func_decl,
                         parent_block,
                         &mut storage.borrow_mut(),
+                        self.u16_type(),
                     )?;
                 }
                 "u32_to_felt252" => {
-                    self.create_libfunc_u32_to_felt252(
+                    self.create_libfunc_uint_to_felt252(
                         func_decl,
                         parent_block,
                         &mut storage.borrow_mut(),
+                        self.u32_type(),
                     )?;
                 }
                 "u64_to_felt252" => {
-                    self.create_libfunc_u64_to_felt252(
+                    self.create_libfunc_uint_to_felt252(
                         func_decl,
                         parent_block,
                         &mut storage.borrow_mut(),
+                        self.u64_type(),
                     )?;
                 }
                 "u128_to_felt252" => {
-                    self.create_libfunc_u128_to_felt252(
+                    self.create_libfunc_uint_to_felt252(
                         func_decl,
                         parent_block,
                         &mut storage.borrow_mut(),
+                        self.u128_type(),
                     )?;
                 }
                 "bitwise" => {
@@ -680,15 +685,16 @@ impl<'ctx> Compiler<'ctx> {
         );
     }
 
-    pub fn create_libfunc_u8_to_felt252(
+    pub fn create_libfunc_uint_to_felt252(
         &'ctx self,
         func_decl: &LibfuncDeclaration,
         parent_block: BlockRef<'ctx>,
         storage: &mut Storage<'ctx>,
+        src_type: Type<'ctx>,
     ) -> Result<()> {
         let region = Region::new();
         let block =
-            region.append_block(Block::new(&[(self.u8_type(), Location::unknown(&self.context))]));
+            region.append_block(Block::new(&[(src_type, Location::unknown(&self.context))]));
 
         let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
         self.op_return(&block, &[op_zext.result(0)?.into()]);
@@ -697,7 +703,7 @@ impl<'ctx> Compiler<'ctx> {
             Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
         let func = self.op_func(
             &id,
-            &create_fn_signature(&[self.u8_type()], &[self.felt_type()]),
+            &create_fn_signature(&[src_type], &[self.felt_type()]),
             vec![region],
             false,
             false,
@@ -706,147 +712,7 @@ impl<'ctx> Compiler<'ctx> {
         storage.libfuncs.insert(
             id,
             FunctionDef {
-                args: vec![SierraType::Simple(self.u8_type())],
-                return_types: vec![SierraType::Simple(self.felt_type())],
-            },
-        );
-        parent_block.append_operation(func);
-
-        Ok(())
-    }
-
-    pub fn create_libfunc_u16_to_felt252(
-        &'ctx self,
-        func_decl: &LibfuncDeclaration,
-        parent_block: BlockRef<'ctx>,
-        storage: &mut Storage<'ctx>,
-    ) -> Result<()> {
-        let region = Region::new();
-        let block =
-            region.append_block(Block::new(&[(self.u16_type(), Location::unknown(&self.context))]));
-
-        let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
-        self.op_return(&block, &[op_zext.result(0)?.into()]);
-
-        let id =
-            Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
-        let func = self.op_func(
-            &id,
-            &create_fn_signature(&[self.u16_type()], &[self.felt_type()]),
-            vec![region],
-            false,
-            false,
-        )?;
-
-        storage.libfuncs.insert(
-            id,
-            FunctionDef {
-                args: vec![SierraType::Simple(self.u16_type())],
-                return_types: vec![SierraType::Simple(self.felt_type())],
-            },
-        );
-        parent_block.append_operation(func);
-
-        Ok(())
-    }
-
-    pub fn create_libfunc_u32_to_felt252(
-        &'ctx self,
-        func_decl: &LibfuncDeclaration,
-        parent_block: BlockRef<'ctx>,
-        storage: &mut Storage<'ctx>,
-    ) -> Result<()> {
-        let region = Region::new();
-        let block =
-            region.append_block(Block::new(&[(self.u32_type(), Location::unknown(&self.context))]));
-
-        let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
-        self.op_return(&block, &[op_zext.result(0)?.into()]);
-
-        let id =
-            Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
-        let func = self.op_func(
-            &id,
-            &create_fn_signature(&[self.u32_type()], &[self.felt_type()]),
-            vec![region],
-            false,
-            false,
-        )?;
-
-        storage.libfuncs.insert(
-            id,
-            FunctionDef {
-                args: vec![SierraType::Simple(self.u32_type())],
-                return_types: vec![SierraType::Simple(self.felt_type())],
-            },
-        );
-        parent_block.append_operation(func);
-
-        Ok(())
-    }
-
-    pub fn create_libfunc_u64_to_felt252(
-        &'ctx self,
-        func_decl: &LibfuncDeclaration,
-        parent_block: BlockRef<'ctx>,
-        storage: &mut Storage<'ctx>,
-    ) -> Result<()> {
-        let region = Region::new();
-        let block =
-            region.append_block(Block::new(&[(self.u64_type(), Location::unknown(&self.context))]));
-
-        let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
-        self.op_return(&block, &[op_zext.result(0)?.into()]);
-
-        let id =
-            Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
-        let func = self.op_func(
-            &id,
-            &create_fn_signature(&[self.u64_type()], &[self.felt_type()]),
-            vec![region],
-            false,
-            false,
-        )?;
-
-        storage.libfuncs.insert(
-            id,
-            FunctionDef {
-                args: vec![SierraType::Simple(self.u64_type())],
-                return_types: vec![SierraType::Simple(self.felt_type())],
-            },
-        );
-        parent_block.append_operation(func);
-
-        Ok(())
-    }
-
-    pub fn create_libfunc_u128_to_felt252(
-        &'ctx self,
-        func_decl: &LibfuncDeclaration,
-        parent_block: BlockRef<'ctx>,
-        storage: &mut Storage<'ctx>,
-    ) -> Result<()> {
-        let region = Region::new();
-        let block = region
-            .append_block(Block::new(&[(self.u128_type(), Location::unknown(&self.context))]));
-
-        let op_zext = self.op_zext(&block, block.argument(0)?.into(), self.felt_type());
-        self.op_return(&block, &[op_zext.result(0)?.into()]);
-
-        let id =
-            Self::normalize_func_name(func_decl.id.debug_name.as_deref().unwrap()).into_owned();
-        let func = self.op_func(
-            &id,
-            &create_fn_signature(&[self.u128_type()], &[self.felt_type()]),
-            vec![region],
-            false,
-            false,
-        )?;
-
-        storage.libfuncs.insert(
-            id,
-            FunctionDef {
-                args: vec![SierraType::Simple(self.u128_type())],
+                args: vec![SierraType::Simple(src_type)],
                 return_types: vec![SierraType::Simple(self.felt_type())],
             },
         );

--- a/sierra2mlir/tests/example_compiles.rs
+++ b/sierra2mlir/tests/example_compiles.rs
@@ -15,4 +15,15 @@ macro_rules! impl_tests {
     };
 }
 
-impl_tests!(casts, destructure, felt_is_zero, fib, fib_simple, print_test, program, simple, types,);
+impl_tests!(
+    casts,
+    destructure,
+    felt_is_zero,
+    fib,
+    fib_simple,
+    print_test,
+    program,
+    simple,
+    types,
+    uint,
+);


### PR DESCRIPTION
# Implement `u???_to_felt252` libfuncs

## Description

Implementation of the following libfuncs:
  - `u8_to_felt252`
  - `u16_to_felt252`
  - `u32_to_felt252`
  - `u64_to_felt252`
  - `u128_to_felt252`

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
