### PR TITLE
Make cairo sources loadable.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install LLVM
         run: sudo apt-get install libllvm-16-ocaml-dev libllvm16 llvm-16 llvm-16-dev llvm-16-doc llvm-16-examples llvm-16-runtime clang-16 clang-tools-16 clang-16-doc libclang-common-16-dev libclang-16-dev libclang1-16 lld-16 libpolly-16-dev libclang-rt-16-dev libc++-16-dev libc++abi-16-dev libmlir-16-dev mlir-16-tools
       - name: Fetch corelibs.
-        run: git clone https://github.com/starkware-libs/cairo.git -o starkware-cairo && cp -r starkware-cairo/corelib . && rm -rf starkware-cairo/
+        run: git clone https://github.com/starkware-libs/cairo.git starkware-cairo && cp -r starkware-cairo/corelib . && rm -rf starkware-cairo/
       - name: cargo test
         run: cargo test --all -- --nocapture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
       - name: Install LLVM
         run: sudo apt-get install libllvm-16-ocaml-dev libllvm16 llvm-16 llvm-16-dev llvm-16-doc llvm-16-examples llvm-16-runtime clang-16 clang-tools-16 clang-16-doc libclang-common-16-dev libclang-16-dev libclang1-16 lld-16 libpolly-16-dev libclang-rt-16-dev libc++-16-dev libc++abi-16-dev libmlir-16-dev mlir-16-tools
+      - name: Fetch corelibs.
+        run: git clone https://github.com/starkware-libs/cairo.git -o starkware-cairo && cp -r starkware-cairo/corelib . && rm -rf starkware-cairo/
       - name: cargo test
         run: cargo test --all -- --nocapture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install LLVM
         run: sudo apt-get install libllvm-16-ocaml-dev libllvm16 llvm-16 llvm-16-dev llvm-16-doc llvm-16-examples llvm-16-runtime clang-16 clang-tools-16 clang-16-doc libclang-common-16-dev libclang-16-dev libclang1-16 lld-16 libpolly-16-dev libclang-rt-16-dev libc++-16-dev libc++abi-16-dev libmlir-16-dev mlir-16-tools
       - name: Fetch corelibs.
-        run: git clone https://github.com/starkware-libs/cairo.git starkware-cairo && cp -r starkware-cairo/corelib . && rm -rf starkware-cairo/
+        run: git clone --depth 1 --branch v1.0.0-alpha.6 https://github.com/starkware-libs/cairo.git starkware-cairo && cp -r starkware-cairo/corelib . && rm -rf starkware-cairo/
       - name: cargo test
         run: cargo test --all -- --nocapture
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,10 +3,10 @@ name = "cli"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-sierra2mlir = { version = "0.1.0", path = "../sierra2mlir" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6"}
+cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.6"}
 clap = { version = "4.1.13", features = ["derive"] }
 color-eyre = "0.6.2"
+sierra2mlir = { version = "0.1.0", path = "../sierra2mlir" }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,9 +4,16 @@
 #![warn(clippy::nursery)]
 #![allow(unused)]
 
+use cairo_lang_compiler::{project::ProjectConfig, CompilerConfig};
+use cairo_lang_sierra::program::Program;
 use clap::{Parser, Subcommand};
 use sierra2mlir::compiler::Compiler;
-use std::{fs, path::PathBuf, time::Instant};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Instant,
+};
 
 #[derive(Parser)]
 #[command(
@@ -83,9 +90,9 @@ fn main() -> color_eyre::Result<()> {
 
     match args.command {
         Commands::Compile { input, optimize, output, debug, main_print, print_target } => {
-            let code = fs::read_to_string(input)?;
+            let program = load_program(&input);
             let mlir_output =
-                sierra2mlir::compile(&code, optimize, debug, main_print, print_target)?;
+                sierra2mlir::compile(&program, optimize, debug, main_print, print_target)?;
 
             if let Some(output) = output {
                 fs::write(output, mlir_output);
@@ -94,8 +101,8 @@ fn main() -> color_eyre::Result<()> {
             }
         }
         Commands::Run { function, input, main_print, print_target } => {
-            let code = fs::read_to_string(input)?;
-            let engine = sierra2mlir::execute(&code, main_print, print_target)?;
+            let program = load_program(&input);
+            let engine = sierra2mlir::execute(&program, main_print, print_target)?;
 
             unsafe {
                 engine.invoke_packed(&function, &mut [])?;
@@ -104,4 +111,21 @@ fn main() -> color_eyre::Result<()> {
     }
 
     Ok(())
+}
+
+fn load_program(input: &Path) -> Program {
+    match input.extension().map(|x| x.to_str().unwrap()) {
+        Some("cairo") => Arc::try_unwrap(
+            cairo_lang_compiler::compile_cairo_project_at_path(
+                input,
+                CompilerConfig { replace_ids: true, ..Default::default() },
+            )
+            .unwrap(),
+        )
+        .unwrap(),
+        Some("sierra") => cairo_lang_sierra::ProgramParser::new()
+            .parse(fs::read_to_string(input).unwrap().as_str())
+            .unwrap(),
+        _ => todo!("unknown file extension"),
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,7 @@ struct Args {
 enum Commands {
     /// Compile to MLIR with LLVM dialect, ready to be converted by `mlir-translate --mlir-to-llvmir`
     Compile {
-        /// The input sierra file.
+        /// Path to the Cairo or Sierra source code.
         input: PathBuf,
 
         /// Output optimized MLIR.
@@ -61,7 +61,7 @@ enum Commands {
     },
     /// Compile and run a program. The entry point must be a function without arguments.
     Run {
-        /// The input sierra file.
+        /// Path to the Cairo or Sierra source code.
         input: PathBuf,
 
         /// The function to run. Can only run functions without arguments and return types.

--- a/sierra2mlir/benches/execution.rs
+++ b/sierra2mlir/benches/execution.rs
@@ -1,7 +1,9 @@
+use cairo_lang_sierra::ProgramParser;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let engine = sierra2mlir::execute(include_str!("programs/fib.sierra"), false, 1).unwrap();
+    let program = ProgramParser::new().parse(include_str!("programs/fib.sierra")).unwrap();
+    let engine = sierra2mlir::execute(&program, false, 1).unwrap();
 
     unsafe {
         engine.invoke_packed("fib_fib_main", &mut []).unwrap();

--- a/sierra2mlir/src/compiler.rs
+++ b/sierra2mlir/src/compiler.rs
@@ -1,4 +1,4 @@
-use cairo_lang_sierra::{program::Program, ProgramParser};
+use cairo_lang_sierra::program::Program;
 use color_eyre::Result;
 use itertools::Itertools;
 use melior_next::{
@@ -17,8 +17,7 @@ use std::{borrow::Cow, cmp::Ordering, collections::HashMap, ops::Deref};
 use crate::{libfuncs::lib_func_def::SierraLibFunc, types::DEFAULT_PRIME};
 
 pub struct Compiler<'ctx> {
-    pub code: String,
-    pub program: Program,
+    pub program: &'ctx Program,
     pub context: Context,
     pub module: Module<'ctx>,
     pub main_print: bool,
@@ -143,10 +142,11 @@ pub struct Storage<'ctx> {
 }
 
 impl<'ctx> Compiler<'ctx> {
-    pub fn new(code: &str, main_print: bool, print_fd: i32) -> color_eyre::Result<Self> {
-        let code = code.to_string();
-        let program: Program = ProgramParser::new().parse(&code).unwrap();
-
+    pub fn new(
+        program: &'ctx Program,
+        main_print: bool,
+        print_fd: i32,
+    ) -> color_eyre::Result<Self> {
         let registry = dialect::Registry::new();
         register_all_dialects(&registry);
 
@@ -178,7 +178,7 @@ impl<'ctx> Compiler<'ctx> {
 
         let module = Module::from_operation(module_op).unwrap();
 
-        Ok(Self { code, program, context, module, main_print, print_fd })
+        Ok(Self { program, context, module, main_print, print_fd })
     }
 }
 

--- a/sierra2mlir/src/lib.rs
+++ b/sierra2mlir/src/lib.rs
@@ -10,6 +10,7 @@ use melior_next::{pass, utility::register_all_passes, ExecutionEngine};
 use tracing::debug;
 
 use crate::compiler::Compiler;
+use cairo_lang_sierra::program::Program;
 
 pub mod compiler;
 mod libfuncs;
@@ -19,14 +20,14 @@ mod userfuncs;
 mod utility;
 
 pub fn compile(
-    code: &str,
+    program: &Program,
     optimized: bool,
     debug_info: bool,
     // TODO: Make this an enum with either: stdout, stderr, a path to a file, or a raw fd (pipes?).
     main_print: bool,
     print_fd: i32,
 ) -> Result<String, color_eyre::Report> {
-    let mut compiler = Compiler::new(code, main_print, print_fd)?;
+    let mut compiler = Compiler::new(program, main_print, print_fd)?;
     compiler.compile()?;
 
     debug!("mlir before pass:\n{}", compiler.module.as_operation());
@@ -64,11 +65,11 @@ pub fn compile(
 }
 
 pub fn execute(
-    code: &str,
+    program: &Program,
     main_print: bool,
     print_fd: i32,
 ) -> Result<ExecutionEngine, color_eyre::Report> {
-    let mut compiler = Compiler::new(code, main_print, print_fd)?;
+    let mut compiler = Compiler::new(program, main_print, print_fd)?;
     compiler.compile()?;
 
     let pass_manager = pass::Manager::new(&compiler.context);

--- a/sierra2mlir/src/statements/mod.rs
+++ b/sierra2mlir/src/statements/mod.rs
@@ -64,7 +64,7 @@ impl<'ctx> Compiler<'ctx> {
     // Process the statements of the sierra program by breaking flow up into basic blocks and processing one at a time
     pub fn process_statements(&'ctx self, storage: &mut Storage<'ctx>) -> Result<()> {
         // Calculate the basic block structure in each function
-        let block_ranges_per_function = calculate_block_ranges_per_function(&self.program);
+        let block_ranges_per_function = calculate_block_ranges_per_function(self.program);
 
         // Process the blocks for each function
         for (func_start, (func, block_flows)) in block_ranges_per_function {

--- a/sierra2mlir/src/userfuncs/mod.rs
+++ b/sierra2mlir/src/userfuncs/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 impl<'ctx> Compiler<'ctx> {
     pub fn process_functions(&'ctx self, storage: &mut Storage<'ctx>) -> Result<()> {
         // First, create the user func defs without internal block information
-        self.save_nonflow_function_info_to_storage(&self.program, storage);
+        self.save_nonflow_function_info_to_storage(self.program, storage);
 
         // Add a wrapper around the main function to print the felt representation of its returns if the option to do so was passed
         self.create_wrappers_if_necessary(storage)?;
@@ -75,7 +75,7 @@ impl<'ctx> Compiler<'ctx> {
         // For complex types, their components types must be added to the list before them
         let types_to_print = get_all_types_to_print(
             &ret_type_declarations.iter().map(|(_t, decl)| (*decl).clone()).collect_vec(),
-            &self.program,
+            self.program,
         );
 
         for type_decl in types_to_print {

--- a/sierra2mlir/tests/comparison.rs
+++ b/sierra2mlir/tests/comparison.rs
@@ -82,12 +82,14 @@ fn run_sierra_via_casm(sierra_code: &str) -> Result<RunResult> {
 
 // Runs the test file via compiling to mlir, then llir, then invoking lli to run it
 fn run_sierra_via_llvm(test_name: &str, sierra_code: &str) -> Result<Vec<BigUint>, String> {
+    let program = ProgramParser::new().parse(sierra_code).unwrap();
+
     let tmp_dir = tempdir::TempDir::new("test_comparison").unwrap().into_path();
 
     let mlir_file = tmp_dir.join(format!("{test_name}.mlir")).display().to_string();
     let output_file = tmp_dir.join(format!("{test_name}.ll")).display().to_string();
 
-    let compiled_code = compile(sierra_code, false, false, true, 1).unwrap();
+    let compiled_code = compile(&program, false, false, true, 1).unwrap();
     std::fs::write(mlir_file.as_str(), compiled_code).unwrap();
 
     let mlir_prefix = std::env::var("MLIR_SYS_160_PREFIX").unwrap();

--- a/sierra2mlir/tests/example_compiles.rs
+++ b/sierra2mlir/tests/example_compiles.rs
@@ -3,13 +3,15 @@ macro_rules! impl_tests {
         $(
             #[test]
             fn $name() {
+                use cairo_lang_sierra::ProgramParser;
                 use std::fs::read_to_string;
 
                 let program_path = concat!("../examples/", stringify!($name), ".sierra");
                 let sierra_source =
                     read_to_string(program_path).expect("Could not read Sierra source code");
 
-                sierra2mlir::compile(&sierra_source, false, false, false, 1).expect("Error compiling sierra program");
+                let program = ProgramParser::new().parse(&sierra_source).unwrap();
+                sierra2mlir::compile(&program, false, false, false, 1).expect("Error compiling sierra program");
             }
         )*
     };


### PR DESCRIPTION
# Make Cairo source code loadable

## Description

Allow loading Cairo files directly, without having to convert them to Sierra first.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
