### PR TITLE
fix bench and a assertion due to transform order

### DIFF
--- a/sierra2mlir/benches/execution.rs
+++ b/sierra2mlir/benches/execution.rs
@@ -6,13 +6,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let engine = sierra2mlir::execute(&program, false, 1).unwrap();
 
     unsafe {
-        engine.invoke_packed("fib_fib_main", &mut []).unwrap();
+        engine.invoke_packed("fib::fib::main", &mut []).unwrap();
     };
 
     c.bench_with_input(BenchmarkId::new("MLIR", 1), &(engine), |b, engine| {
         b.iter(|| {
             unsafe {
-                engine.invoke_packed("fib_fib_main", &mut []).ok();
+                engine.invoke_packed("fib::fib::main", &mut []).ok();
             };
         });
     });

--- a/sierra2mlir/src/lib.rs
+++ b/sierra2mlir/src/lib.rs
@@ -34,6 +34,12 @@ pub fn compile(
     let pass_manager = pass::Manager::new(&compiler.context);
     register_all_passes();
 
+    pass_manager.add_pass(pass::conversion::convert_func_to_llvm());
+    pass_manager.add_pass(pass::conversion::convert_scf_to_cf());
+    pass_manager.add_pass(pass::conversion::convert_cf_to_llvm());
+    //pass_manager.add_pass(pass::conversion::convert_gpu_to_llvm());
+    pass_manager.add_pass(pass::conversion::convert_arithmetic_to_llvm());
+
     if optimized {
         pass_manager.add_pass(pass::transform::canonicalizer());
         pass_manager.add_pass(pass::transform::inliner());
@@ -41,12 +47,6 @@ pub fn compile(
         pass_manager.add_pass(pass::transform::cse());
         pass_manager.add_pass(pass::transform::sccp());
     }
-
-    pass_manager.add_pass(pass::conversion::convert_func_to_llvm());
-    pass_manager.add_pass(pass::conversion::convert_scf_to_cf());
-    pass_manager.add_pass(pass::conversion::convert_cf_to_llvm());
-    //pass_manager.add_pass(pass::conversion::convert_gpu_to_llvm());
-    pass_manager.add_pass(pass::conversion::convert_arithmetic_to_llvm());
 
     // pass_manager.add_pass(pass::transform::print_operation_stats());
     pass_manager.enable_verifier(true);
@@ -74,16 +74,18 @@ pub fn execute(
 
     let pass_manager = pass::Manager::new(&compiler.context);
     register_all_passes();
+    pass_manager.add_pass(pass::conversion::convert_func_to_llvm());
+    pass_manager.add_pass(pass::conversion::convert_scf_to_cf());
+    pass_manager.add_pass(pass::conversion::convert_cf_to_llvm());
+    //pass_manager.add_pass(pass::conversion::convert_gpu_to_llvm());
+    pass_manager.add_pass(pass::conversion::convert_arithmetic_to_llvm());
+
     pass_manager.add_pass(pass::transform::canonicalizer());
     pass_manager.add_pass(pass::transform::inliner());
     pass_manager.add_pass(pass::transform::symbol_dce());
     pass_manager.add_pass(pass::transform::cse());
     pass_manager.add_pass(pass::transform::sccp());
-    pass_manager.add_pass(pass::conversion::convert_scf_to_cf());
-    pass_manager.add_pass(pass::conversion::convert_cf_to_llvm());
-    //pass_manager.add_pass(pass::conversion::convert_gpu_to_llvm());
-    pass_manager.add_pass(pass::conversion::convert_func_to_llvm());
-    pass_manager.add_pass(pass::conversion::convert_arithmetic_to_llvm());
+
     pass_manager.enable_verifier(true);
     pass_manager.run(&mut compiler.module)?;
 


### PR DESCRIPTION
the bench stopped working due to a change in the function naming.

also i reorder the transform passes to be after the conversions due to it triggering a llvm assertion (they show if you compile llvm with assertions on, which aid development)