### PR TITLE
Make MLIR C utils library work on linux, macos and windows.

### DIFF
--- a/sierra2mlir/Cargo.toml
+++ b/sierra2mlir/Cargo.toml
@@ -17,6 +17,7 @@ harness = false
 [dependencies]
 cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.7" }
 cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", tag = "v1.0.0-alpha.7" }
+cfg-match = "0.2.1"
 color-eyre = "0.6.2"
 itertools = "0.10.5"
 melior-asm = { git = "https://github.com/azteca1998/melior-asm" }


### PR DESCRIPTION
# Make MLIR C utils library work on linux, macos and windows

## Description

Linking the MLIR C utils library (for the JIT engine) currently works only on linux due to the library extension (`.so`). This PR fixes that issue and makes it so that it'll work in the three main OSes.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
