### PR TITLE
Implement `pedersen` libfunc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 
 members = [
     "sierra2mlir",
+    "sierra2mlir-utils",
     "cli"
 ]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,6 +102,10 @@ fn main() -> color_eyre::Result<()> {
         }
         Commands::Run { function, input, main_print, print_target } => {
             let program = load_program(&input);
+            if !program.funcs.iter().any(|x| x.id.debug_name.as_deref() == Some(&function)) {
+                panic!("Entry point {function} doesn't exist.");
+            }
+
             let engine = sierra2mlir::execute(&program, main_print, print_target)?;
 
             unsafe {

--- a/examples/pedersen.cairo
+++ b/examples/pedersen.cairo
@@ -1,5 +1,10 @@
+use debug::PrintTrait;
 use hash::pedersen;
 
 fn test_pedersen() -> felt252 {
     pedersen(pedersen(pedersen(1, 2), 3), 4)
+}
+
+fn main() {
+    test_pedersen().print();
 }

--- a/examples/pedersen.cairo
+++ b/examples/pedersen.cairo
@@ -1,0 +1,5 @@
+use hash::pedersen;
+
+fn test_pedersen() -> felt252 {
+    pedersen(pedersen(pedersen(1, 2), 3), 4)
+}

--- a/sierra2mlir-utils/Cargo.toml
+++ b/sierra2mlir-utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sierra2mlir-utils"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["lib", "cdylib", "staticlib"]
+
+[dependencies]
+starknet-crypto = "0.4.3"

--- a/sierra2mlir-utils/src/lib.rs
+++ b/sierra2mlir-utils/src/lib.rs
@@ -1,0 +1,25 @@
+use core::slice;
+use starknet_crypto::FieldElement;
+
+/// Compute `pedersen(lhs, rhs)` and store it into `dst`.
+///
+/// All its operands need the values in big endian.
+///
+/// # Panics
+///
+/// This function will panic if either operand is out of range for a felt.
+#[no_mangle]
+pub unsafe extern "C" fn sierra2mlir_util_pedersen(dst: *mut u8, lhs: *const u8, rhs: *const u8) {
+    // Extract arrays from the pointers.
+    let dst = slice::from_raw_parts_mut(dst, 32);
+    let lhs = slice::from_raw_parts(lhs, 32);
+    let rhs = slice::from_raw_parts(rhs, 32);
+
+    // Convert to FieldElement.
+    let lhs = FieldElement::from_byte_slice_be(lhs).unwrap();
+    let rhs = FieldElement::from_byte_slice_be(rhs).unwrap();
+
+    // Compute pedersen hash and copy the result into `dst`.
+    let res = starknet_crypto::pedersen_hash(&lhs, &rhs);
+    dst.copy_from_slice(&res.to_bytes_be());
+}

--- a/sierra2mlir/src/compiler.rs
+++ b/sierra2mlir/src/compiler.rs
@@ -162,18 +162,6 @@ impl<'ctx> Compiler<'ctx> {
         Type::integer(&self.context, 256)
     }
 
-    /// Type `Bitwise`. Points to the bitwise builtin pointer. Since we're not respecting the
-    /// classic segments this type makes no sense, therefore it's implemented as `()`.
-    pub fn bitwise_type(&self) -> Type {
-        Type::none(&self.context)
-    }
-
-    /// Type `Bitwise`. Points to the range check builtin pointer. Since we're not respecting the
-    /// classic segments this type makes no sense, therefore it's implemented as `()`.
-    pub fn range_check_type(&self) -> Type {
-        Type::none(&self.context)
-    }
-
     /// The enum struct type. Needed due to some libfuncs using it.
     ///
     /// The tag value is the boolean value: 0, 1

--- a/sierra2mlir/src/lib.rs
+++ b/sierra2mlir/src/lib.rs
@@ -103,16 +103,25 @@ pub fn execute(
     let engine = ExecutionEngine::new(
         &compiler.module,
         2,
-        &[&format!("{}/libmlir_c_runner_utils.{}", run_llvm_config(&["--libdir"]).trim(), {
-            cfg_match! {
-                target_os = "linux" => "so",
-                target_os = "macos" => "dylib",
-                target_os = "windows" => "dll",
-                _ => compile_error!("Unsupported OS."),
-            }
-        })],
+        &[
+            &format!(
+                "{}/libmlir_c_runner_utils.{}",
+                run_llvm_config(&["--libdir"]).trim(),
+                shared_library_extension()
+            ),
+            &format!("target/debug/libsierra2mlir_utils.{}", shared_library_extension()),
+        ],
         false,
     );
 
     Ok(engine)
+}
+
+pub const fn shared_library_extension() -> &'static str {
+    cfg_match! {
+        target_os = "linux" => "so",
+        target_os = "macos" => "dylib",
+        target_os = "windows" => "dll",
+        _ => compile_error!("Unsupported OS."),
+    }
 }

--- a/sierra2mlir/src/libfuncs/mod.rs
+++ b/sierra2mlir/src/libfuncs/mod.rs
@@ -341,6 +341,9 @@ impl<'ctx> Compiler<'ctx> {
                 "print" => {
                     self.create_libfunc_print(func_decl, parent_block, storage)?;
                 }
+                "pedersen" => {
+                    self.create_libfunc_pedersen(func_decl, parent_block, storage)?;
+                }
                 _ => todo!(
                     "unhandled libfunc: {:?}",
                     func_decl.id.debug_name.as_ref().unwrap().as_str()
@@ -2101,6 +2104,75 @@ impl<'ctx> Compiler<'ctx> {
                 }],
                 vec![],
             ),
+        );
+
+        Ok(())
+    }
+
+    pub fn create_libfunc_pedersen(
+        &'ctx self,
+        func_decl: &LibfuncDeclaration,
+        parent_block: BlockRef<'ctx>,
+        storage: &mut Storage<'ctx>,
+    ) -> Result<()> {
+        mlir_asm! { parent_block =>
+            func.func @pedersen(%0 : i256, %1 : i256) -> i256 {
+                // Allocate temporary buffers.
+                %2 = memref.alloca() : memref<32xi8>
+                %3 = memref.alloca() : memref<32xi8>
+                %4 = memref.alloca() : memref<32xi8>
+
+                // Swap endianness (LE -> BE).
+                // TODO: Find a way to check the target's endianness.
+                %5 = llvm.call_intrinsic "llvm.bswap.i256"(%0) : (i256) -> i256
+                %6 = llvm.call_intrinsic "llvm.bswap.i256"(%1) : (i256) -> i256
+
+                // Store lhs and rhs into the temporary buffers.
+                %7 = index.constant 0
+                %8 = memref.view %2[%7][] : memref<32xi8> to memref<i256>
+                %9 = memref.view %3[%7][] : memref<32xi8> to memref<i256>
+                memref.store %5, %8[] : memref<i256>
+                memref.store %6, %9[] : memref<i256>
+
+                // Call the auxiliary library's pedersen function.
+                %10 = memref.extract_aligned_pointer_as_index %2 : memref<32xi8> -> index
+                %11 = memref.extract_aligned_pointer_as_index %3 : memref<32xi8> -> index
+                %12 = memref.extract_aligned_pointer_as_index %4 : memref<32xi8> -> index
+                %13 = index.castu %10 : index to i64
+                %14 = index.castu %11 : index to i64
+                %15 = index.castu %12 : index to i64
+                %16 = llvm.inttoptr %13 : i64 to !llvm.ptr
+                %17 = llvm.inttoptr %14 : i64 to !llvm.ptr
+                %18 = llvm.inttoptr %15 : i64 to !llvm.ptr
+                func.call @sierra2mlir_util_pedersen(%16, %17, %18) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+
+                // Load dst from the temporary buffer.
+                %19 = memref.view %2[%7][] : memref<32xi8> to memref<i256>
+                %20 = memref.load %19[] : memref<i256>
+
+                // Swap endianness (BE -> LE).
+                // TODO: Find a way to check the target's endianness.
+                %21 = llvm.call_intrinsic "llvm.bswap.i256"(%20) : (i256) -> i256
+
+                return %21 : i256
+            }
+
+            func.func private @sierra2mlir_util_pedersen(!llvm.ptr, !llvm.ptr, !llvm.ptr)
+        }
+
+        let id = func_decl.id.debug_name.as_deref().unwrap();
+        storage.libfuncs.insert(
+            id.to_string(),
+            SierraLibFunc::Function {
+                args: vec![
+                    PositionalArg { loc: 1, ty: SierraType::Simple(self.felt_type()) },
+                    PositionalArg { loc: 2, ty: SierraType::Simple(self.felt_type()) },
+                ],
+                return_types: vec![PositionalArg {
+                    loc: 1,
+                    ty: SierraType::Simple(self.felt_type()),
+                }],
+            },
         );
 
         Ok(())

--- a/sierra2mlir/src/libfuncs/mod.rs
+++ b/sierra2mlir/src/libfuncs/mod.rs
@@ -2129,8 +2129,8 @@ impl<'ctx> Compiler<'ctx> {
 
                 // Store lhs and rhs into the temporary buffers.
                 %7 = index.constant 0
-                %8 = memref.view %2[%7][] : memref<32xi8> to memref<i256>
-                %9 = memref.view %3[%7][] : memref<32xi8> to memref<i256>
+                %8 = memref.view %3[%7][] : memref<32xi8> to memref<i256>
+                %9 = memref.view %4[%7][] : memref<32xi8> to memref<i256>
                 memref.store %5, %8[] : memref<i256>
                 memref.store %6, %9[] : memref<i256>
 

--- a/sierra2mlir/src/types/mod.rs
+++ b/sierra2mlir/src/types/mod.rs
@@ -229,5 +229,5 @@ impl<'ctx> Compiler<'ctx> {
 }
 
 pub fn is_omitted_builtin_type(type_name: &str) -> bool {
-    type_name == "Bitwise" || type_name == "RangeCheck"
+    type_name == "Bitwise" || type_name == "Pedersen" || type_name == "RangeCheck"
 }

--- a/sierra2mlir/src/userfuncs/mod.rs
+++ b/sierra2mlir/src/userfuncs/mod.rs
@@ -292,7 +292,7 @@ fn get_all_types_to_print(
                 }
             }
             // Specifically omit these types
-            "RangeCheck" | "Bitwise" => {}
+            "Bitwise" | "Pedersen" | "RangeCheck" => {}
             _ => todo!("Felt representation for {}", type_category),
         }
     }


### PR DESCRIPTION
# Implementation of the `pedersen` libfunc.

## Description

This PR adds an auxiliary library to be linked with the JIT engine or the final executables, which implements a wrapper to StarkNet's pedersen hashing function.
This auxiliary library is then used to implement the `pedersen` libfunc.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
